### PR TITLE
Fix deprecation warnings..

### DIFF
--- a/src/main/scala/org/moe/interpreter/Interpreter.scala
+++ b/src/main/scala/org/moe/interpreter/Interpreter.scala
@@ -18,7 +18,7 @@ object Interpreter {
             case ScopeNode           ( body  ) => eval( new MoeEnvironment( env ), body )
             case StatementsNode      ( nodes ) => {
                 var result : MoeObject = Runtime.NativeObjects.getUndef()
-                for ( val node <- nodes ) {
+                for ( node <- nodes ) {
                     result = eval( env, node )
                 }
                 result
@@ -54,7 +54,7 @@ object Interpreter {
 
             case HashLiteralNode ( map ) => {
                 val hash = HashMap[ String, MoeObject ]()
-                for ( val pair <- map ) {
+                for ( pair <- map ) {
                     val p = eval( env, pair )
                     // NOTE:
                     // forcing each element to become

--- a/src/main/scala/org/moe/runtime/MoeObject.scala
+++ b/src/main/scala/org/moe/runtime/MoeObject.scala
@@ -2,7 +2,7 @@ package org.moe.runtime
 
 class MoeObject {
 
-    private val id : Integer = System.identityHashCode( this )
+    private val id : Int = System.identityHashCode( this )
 
     private var klass : MoeClass = _    
 
@@ -11,7 +11,7 @@ class MoeObject {
         klass = k
     }
 
-    def getID              (): Integer  = id
+    def getID              (): Int  = id
     def getAssociatedClass (): MoeClass = klass
     def hasAssociatedClass (): Boolean  = klass != null
 

--- a/src/test/scala/org/moe/runtime/MoeObjectTestSuite.scala
+++ b/src/test/scala/org/moe/runtime/MoeObjectTestSuite.scala
@@ -11,10 +11,6 @@ class MoeObjectTestSuite extends FunSuite with BeforeAndAfter {
         o = new MoeObject()
     }
 
-    test("... all MoeObjects have an id") {
-        assert( o.getID != null )
-    }
-
     test("... MoeObjects do not have a default class") {
         assert( !o.hasAssociatedClass )
     }


### PR DESCRIPTION
The 'val' in the for comprehension is unneeded and deprecated, so I removed it.
'Integer' is deprecated - I've switched to the Scala specific Int, which can
never be null..
