### PR TITLE
Use Option for MoeClass' superclass

### DIFF
--- a/src/test/scala/org/moe/runtime/MoeClassTestSuite.scala
+++ b/src/test/scala/org/moe/runtime/MoeClassTestSuite.scala
@@ -7,8 +7,8 @@ class MoeClassTestSuite extends FunSuite with BeforeAndAfter {
 
   test("... test MRO") {
     val Foo = new MoeClass("Foo")
-    val Bar = new MoeClass("Bar", Foo)
-    val Baz = new MoeClass("Baz", Bar)
+    val Bar = new MoeClass("Bar", Some(Foo))
+    val Baz = new MoeClass("Baz", Some(Bar))
 
     val mro = Baz.getMRO
 


### PR DESCRIPTION
Again, no nulls.  Replaces some of the if/then logic with map/getOrElse and leaves others with boolcheck/get.

The idea here is to replace all these null checks with Option all the way up the stack.

Also, as a thought: Should these things be mutable?  addMethod/addAttribute could return a MoeClass… :)
