### PR TITLE
More cleanup and improvement

### DIFF
--- a/src/main/scala/org/moe/ast/AST.scala
+++ b/src/main/scala/org/moe/ast/AST.scala
@@ -13,6 +13,11 @@ case class StatementsNode(nodes: List[AST]) extends AST
 
 // literals
 
+/**
+ * A literal Int node
+ *
+ * @param value The Int value of this node
+ */
 case class IntLiteralNode(value: Int) extends AST
 case class FloatLiteralNode(value: Double) extends AST
 case class StringLiteralNode(value: String) extends AST

--- a/src/main/scala/org/moe/interpreter/Interpreter.scala
+++ b/src/main/scala/org/moe/interpreter/Interpreter.scala
@@ -52,20 +52,20 @@ object Interpreter {
     case PairLiteralNode(key, value) => Runtime.NativeObjects.getPair(key -> eval(env, value))
 
     case HashLiteralNode(map) => {
-      val hash = HashMap[String, MoeObject]()
-      for (pair <- map) {
-        val p = eval(env, pair)
-        // NOTE:
-        // forcing each element to become
-        // a single MoePairObject might be
-        // a little too restrictive, it
-        // should (in theory) be possible
-        // for it to evaluate into many
-        // MoePairObject instances as well
-        // - SL
-        hash += p.asInstanceOf[ MoePairObject ].getNativeValue
-      }
-      Runtime.NativeObjects.getHash(hash)
+      // NOTE:
+      // forcing each element to become
+      // a single MoePairObject might be
+      // a little too restrictive, it
+      // should (in theory) be possible
+      // for it to evaluate into many
+      // MoePairObject instances as well
+      // - SL
+      Runtime.NativeObjects.getHash(
+        map.map(
+          pair => eval(env, pair)
+          .asInstanceOf[MoePairObject].getNativeValue
+        ).toMap
+      )
     }
 
     // unary operators

--- a/src/main/scala/org/moe/runtime/MoeAttribute.scala
+++ b/src/main/scala/org/moe/runtime/MoeAttribute.scala
@@ -1,11 +1,16 @@
 package org.moe.runtime
 
-class MoeAttribute (
-  private val name    : String,
-  private val default : MoeObject)
+class MoeAttribute(private val name: String, private val default: MoeObject)
   extends MoeObject {
 
+  /**
+   * Return the name of this attribute.
+   */
   def getName: String = name
+
+  /**
+   * Return default value of this attribute.
+   */
   def getDefault: MoeObject = default
 }
 

--- a/src/main/scala/org/moe/runtime/MoeNativeObject.scala
+++ b/src/main/scala/org/moe/runtime/MoeNativeObject.scala
@@ -1,7 +1,5 @@
 package org.moe.runtime
 
-import scala.collection.mutable.HashMap
-
 abstract class MoeNativeObject[A] (private val value: A) extends MoeObject {
   def this(v: A, c: Option[MoeClass]) = { this(v); setAssociatedClass(c) }
   def getNativeValue: A = value.asInstanceOf[A]
@@ -59,7 +57,7 @@ class MoeArrayObject(v: List[MoeObject]) extends MoeNativeObject[List[MoeObject]
   override def isFalse: Boolean = getNativeValue.size == 0
 }
 
-class MoeHashObject(v: HashMap[String, MoeObject]) extends MoeNativeObject[HashMap[String, MoeObject]](v) {
+class MoeHashObject(v: Map[String, MoeObject]) extends MoeNativeObject[Map[String, MoeObject]](v) {
   override def isFalse: Boolean = getNativeValue.size == 0
 }
 

--- a/src/main/scala/org/moe/runtime/MoeObject.scala
+++ b/src/main/scala/org/moe/runtime/MoeObject.scala
@@ -3,7 +3,7 @@ package org.moe.runtime
 /** An object!
  * @param associatedClass The class to associated with this object.
  */
-class MoeObject(associatedClass: Option[MoeClass] = None) {
+class MoeObject(private var associatedClass: Option[MoeClass] = None) {
 
   private val id: Int = System.identityHashCode(this)
 

--- a/src/main/scala/org/moe/runtime/MoeRuntime.scala
+++ b/src/main/scala/org/moe/runtime/MoeRuntime.scala
@@ -1,7 +1,5 @@
 package org.moe.runtime
 
-import scala.collection.mutable.HashMap
-
 object Runtime {
 
   private val RootEnv = new MoeEnvironment()
@@ -30,7 +28,7 @@ object Runtime {
     def getString(value: String) = new MoeStringObject(value)
 
     def getPair(value: (String, MoeObject)) = new MoePairObject(value)
-    def getHash(value: HashMap[String, MoeObject]) = new MoeHashObject(value)
+    def getHash(value: Map[String, MoeObject]) = new MoeHashObject(value)
     def getArray(value: List[MoeObject]) = new MoeArrayObject(value)
   }
 

--- a/src/test/scala/org/moe/interpreter/InterpreterTestSuite.scala
+++ b/src/test/scala/org/moe/interpreter/InterpreterTestSuite.scala
@@ -6,8 +6,6 @@ import org.scalatest.BeforeAndAfter
 import org.moe.runtime._
 import org.moe.ast._
 
-import scala.collection.mutable.HashMap
-
 class InterpreterTestSuite extends FunSuite with BeforeAndAfter {
 
   private case class FooNode() extends AST
@@ -111,7 +109,7 @@ class InterpreterTestSuite extends FunSuite with BeforeAndAfter {
     )
     val result = Interpreter.eval(Runtime.getRootEnv, ast)
 
-    val hash: HashMap[String, MoeObject] = result.asInstanceOf[MoeHashObject].getNativeValue
+    val hash: Map[String, MoeObject] = result.asInstanceOf[MoeHashObject].getNativeValue
     assert(hash("foo").asInstanceOf[MoeIntObject].getNativeValue === 10)
     assert(hash("bar").asInstanceOf[MoeIntObject].getNativeValue === 20)
   }
@@ -233,7 +231,7 @@ class InterpreterTestSuite extends FunSuite with BeforeAndAfter {
     val result = Interpreter.eval(Runtime.getRootEnv, ast)
     assert(result.asInstanceOf[MoeIntObject].getNativeValue === 3)
   }
-  
+
   test("... basic (true/true) test with IfElsif (true/true)") {
     val ast = basicAST(
       List(

--- a/src/test/scala/org/moe/runtime/MoeClassTestSuite.scala
+++ b/src/test/scala/org/moe/runtime/MoeClassTestSuite.scala
@@ -7,8 +7,8 @@ class MoeClassTestSuite extends FunSuite with BeforeAndAfter {
 
   test("... test MRO") {
     val Foo = new MoeClass("Foo")
-    val Bar = new MoeClass("Bar", Some(Foo))
-    val Baz = new MoeClass("Baz", Some(Bar))
+    val Bar = new MoeClass(name = "Bar", superclass = Some(Foo))
+    val Baz = new MoeClass(name = "Baz", superclass = Some(Bar))
 
     val mro = Baz.getMRO
 
@@ -20,14 +20,22 @@ class MoeClassTestSuite extends FunSuite with BeforeAndAfter {
   }
 
   test("... test the whole thing together") {
-    val klass = new MoeClass("TestClass", "0.01", "cpan:STEVAN")
+    val klass = new MoeClass(
+      name = "TestClass",
+      version = Some("0.01"),
+      authority = Some("cpan:STEVAN")
+    )
     klass.addMethod(new MoeMethod("ident", (inv, args) => inv))
     var obj = new MoeObject(Some(klass))
     assert(obj.callMethod("ident") === obj)
   }
 
   test("... test the whole thing together (newInstance version)") {
-    val klass = new MoeClass("TestClass", "0.01", "cpan:STEVAN")
+    val klass = new MoeClass(
+      name = "TestClass",
+      version = Some("0.01"),
+      authority = Some("cpan:STEVAN")
+    )
     klass.addMethod(new MoeMethod("ident", (inv, args) => inv))
     var obj = klass.newInstance
     assert(obj.callMethod("ident") === obj)

--- a/src/test/scala/org/moe/runtime/MoeEnvironmentTestSuite.scala
+++ b/src/test/scala/org/moe/runtime/MoeEnvironmentTestSuite.scala
@@ -5,55 +5,55 @@ import org.scalatest.BeforeAndAfter
 
 class MoeEnvironmentTestSuite extends FunSuite with BeforeAndAfter {
 
-    var env : MoeEnvironment = _
+  var env : MoeEnvironment = _
 
-    before {
-        env = new MoeEnvironment()
+  before {
+    env = new MoeEnvironment()
+  }
+
+  test("... this is a root MoeEnvironment") {
+    assert(env.isRoot)
+  }
+
+  test("... there is no value for $foo") {
+    assert(!env.has("$foo"))
+  }
+
+  test("... insert a value into $foo") {
+    val c001 = new MoeObject()
+    env.create("$foo", c001)
+    assert(env.has("$foo"))
+    assert(env.get("$foo") === c001)
+  }
+
+  test("... overwrite a value into $foo") {
+    val c001 = new MoeObject()
+    val c002 = new MoeObject()
+
+    env.create("$foo", c001)
+
+    assert(env.has("$foo"))
+    assert(env.get("$foo") === c001)
+
+    env.set("$foo", c002)
+
+    assert(env.get("$foo") != c001)
+    assert(env.get("$foo") === c002)
+  }
+
+  test("... value not found thrown") {
+    val ex = intercept[Runtime.Errors.ValueNotFound] {
+        env.get("$bar")
     }
+    assert(ex.getMessage === "$bar")
+  }
 
-    test("... this is a root MoeEnvironment") {
-        assert(env.isRoot)
+  test("... undefined value thrown") {
+    val c001 = new MoeObject()
+    val ex = intercept[Runtime.Errors.UndefinedValue] {
+      env.set("$baz", c001)
     }
-
-    test("... there is no value for $foo") {
-        assert(!env.has("$foo"))
-    }
-
-    test("... insert a value into $foo") {
-        val c001 = new MoeObject()
-        env.create("$foo", c001)
-        assert(env.has("$foo"))
-        assert(env.get("$foo") === c001)
-    }
-
-    test("... overwrite a value into $foo") {
-        val c001 = new MoeObject()
-        val c002 = new MoeObject()
-
-        env.create("$foo", c001)
-
-        assert(env.has("$foo"))
-        assert(env.get("$foo") === c001)
-
-        env.set("$foo", c002)
-
-        assert(env.get("$foo") != c001)
-        assert(env.get("$foo") === c002)
-    }
-
-    test("... value not found thrown") {
-        val ex = intercept[Runtime.Errors.ValueNotFound] {
-            env.get("$bar")
-        }
-        assert(ex.getMessage === "$bar")
-    }
-
-    test("... undefined value thrown") {
-        val c001 = new MoeObject()
-        val ex = intercept[Runtime.Errors.UndefinedValue] {
-            env.set("$baz", c001)
-        }
-        assert(ex.getMessage === "$baz")
-    }
+    assert(ex.getMessage === "$baz")
+  }
 
 }

--- a/src/test/scala/org/moe/runtime/MoeMethodTestSuite.scala
+++ b/src/test/scala/org/moe/runtime/MoeMethodTestSuite.scala
@@ -5,19 +5,19 @@ import org.scalatest.BeforeAndAfter
 
 class MoeMethodTestSuite extends FunSuite with BeforeAndAfter {
 
-    test("... basic method") {
-        val invocant = new MoeObject()
-        val method   = new MoeMethod("ident", (inv, args) => inv)
-        val result   = method.execute(invocant, List())
-        assert(result === invocant)
-    }
+  test("... basic method") {
+    val invocant = new MoeObject()
+    val method   = new MoeMethod("ident", (inv, args) => inv)
+    val result   = method.execute(invocant, List())
+    assert(result === invocant)
+  }
 
-    test("... basic yadda-yadda-yadda method") {
-        val invocant = new MoeObject()
-        val method   = new MoeMethod("yadda_yadda_yadda")
-        intercept[Runtime.Errors.UndefinedMethod] {
-            method.execute(invocant, List())
-        }
+  test("... basic yadda-yadda-yadda method") {
+    val invocant = new MoeObject()
+    val method   = new MoeMethod("yadda_yadda_yadda")
+    intercept[Runtime.Errors.UndefinedMethod] {
+      method.execute(invocant, List())
     }
+  }
 
 }

--- a/src/test/scala/org/moe/runtime/MoeNativeObjectTestSuite.scala
+++ b/src/test/scala/org/moe/runtime/MoeNativeObjectTestSuite.scala
@@ -3,192 +3,190 @@ package org.moe.runtime
 import org.scalatest.FunSuite
 import org.scalatest.BeforeAndAfter
 
-import scala.collection.mutable.HashMap
-
 class MoeNativeObjectTestSuite extends FunSuite with BeforeAndAfter {
 
-    test("... simple String object") {
-        val o = new MoeStringObject("Hello World")
-        assert(o.getNativeValue === "Hello World")
-        assert(o.isTrue)
-        assert(!o.isFalse)
-        assert(!o.isUndef)
-    }
+  test("... simple String object") {
+    val o = new MoeStringObject("Hello World")
+    assert(o.getNativeValue === "Hello World")
+    assert(o.isTrue)
+    assert(!o.isFalse)
+    assert(!o.isUndef)
+  }
 
-    test("... false String object - empty string") {
-        val o = new MoeStringObject("")
-        assert(o.getNativeValue === "")
-        assert(!o.isTrue)
-        assert(o.isFalse)
-        assert(!o.isUndef)
-    }
+  test("... false String object - empty string") {
+    val o = new MoeStringObject("")
+    assert(o.getNativeValue === "")
+    assert(!o.isTrue)
+    assert(o.isFalse)
+    assert(!o.isUndef)
+  }
 
-    test("... false String object - zero") {
-        val o = new MoeStringObject("0")
-        assert(o.getNativeValue === "0")
-        assert(!o.isTrue)
-        assert(o.isFalse)
-        assert(!o.isUndef)
-    }
+  test("... false String object - zero") {
+    val o = new MoeStringObject("0")
+    assert(o.getNativeValue === "0")
+    assert(!o.isTrue)
+    assert(o.isFalse)
+    assert(!o.isUndef)
+  }
 
-    test("... false String object - zerozero") {
-        val o = new MoeStringObject("00")
-        assert(o.getNativeValue === "00")
-        assert(o.isTrue)
-        assert(!o.isFalse)
-        assert(!o.isUndef)
-    }
+  test("... false String object - zerozero") {
+    val o = new MoeStringObject("00")
+    assert(o.getNativeValue === "00")
+    assert(o.isTrue)
+    assert(!o.isFalse)
+    assert(!o.isUndef)
+  }
 
-    test("... simple Int object") {
-        val o = new MoeIntObject(10)
-        assert(o.getNativeValue === 10)
-        assert(o.isTrue)
-        assert(!o.isFalse)
-        assert(!o.isUndef)
-    }
+  test("... simple Int object") {
+      val o = new MoeIntObject(10)
+      assert(o.getNativeValue === 10)
+      assert(o.isTrue)
+      assert(!o.isFalse)
+      assert(!o.isUndef)
+  }
 
-    test("... false Int object") {
-        val o = new MoeIntObject(0)
-        assert(o.getNativeValue === 0)
-        assert(!o.isTrue)
-        assert(o.isFalse)
-        assert(!o.isUndef)
-    }
+  test("... false Int object") {
+    val o = new MoeIntObject(0)
+    assert(o.getNativeValue === 0)
+    assert(!o.isTrue)
+    assert(o.isFalse)
+    assert(!o.isUndef)
+  }
 
-    test("... simple Float object") {
-        val o = new MoeFloatObject(10.5)
-        assert(o.getNativeValue === 10.5)
-        assert(o.isTrue)
-        assert(!o.isFalse)
-        assert(!o.isUndef)
-    }
+  test("... simple Float object") {
+      val o = new MoeFloatObject(10.5)
+      assert(o.getNativeValue === 10.5)
+      assert(o.isTrue)
+      assert(!o.isFalse)
+      assert(!o.isUndef)
+  }
 
-    test("... false Float object") {
-        val o = new MoeFloatObject(0.0)
-        assert(o.getNativeValue === 0.0)
-        assert(!o.isTrue)
-        assert(o.isFalse)
-        assert(!o.isUndef)
-    }
+  test("... false Float object") {
+      val o = new MoeFloatObject(0.0)
+      assert(o.getNativeValue === 0.0)
+      assert(!o.isTrue)
+      assert(o.isFalse)
+      assert(!o.isUndef)
+  }
 
-    test("... simple Boolean object") {
-        val o = new MoeBooleanObject(true)
-        assert(o.getNativeValue === true)
-        assert(o.isTrue)
-        assert(!o.isFalse)
-        assert(!o.isUndef)
-    }
+  test("... simple Boolean object") {
+      val o = new MoeBooleanObject(true)
+      assert(o.getNativeValue === true)
+      assert(o.isTrue)
+      assert(!o.isFalse)
+      assert(!o.isUndef)
+  }
 
-    test("... false Boolean object") {
-        val o = new MoeBooleanObject(false)
-        assert(o.getNativeValue === false)
-        assert(!o.isTrue)
-        assert(o.isFalse)
-        assert(!o.isUndef)
-    }
+  test("... false Boolean object") {
+    val o = new MoeBooleanObject(false)
+    assert(o.getNativeValue === false)
+    assert(!o.isTrue)
+    assert(o.isFalse)
+    assert(!o.isUndef)
+  }
 
-    test("... simple Null object") {
-        val o = new MoeNullObject()
-        assert(o.getNativeValue === null)
-        assert(!o.isTrue)
-        assert(o.isFalse)
-        assert(o.isUndef)
-    }
+  test("... simple Null object") {
+    val o = new MoeNullObject()
+    assert(o.getNativeValue === null)
+    assert(!o.isTrue)
+    assert(o.isFalse)
+    assert(o.isUndef)
+  }
 
-    test("... simple Array object") {
-        val o = new MoeArrayObject(
-            List(
-                new MoeNullObject(),
-                new MoeIntObject(10)
-           )
-       )
-        val array = o.getNativeValue
-        assert(array(0).asInstanceOf[ MoeNullObject ].getNativeValue === null)
-        assert(array(1).asInstanceOf[ MoeIntObject ].getNativeValue === 10)
-        assert(o.isTrue)
-        assert(!o.isFalse)
-        assert(!o.isUndef)
-    }
+  test("... simple Array object") {
+    val o = new MoeArrayObject(
+      List(
+        new MoeNullObject(),
+        new MoeIntObject(10)
+      )
+    )
+    val array = o.getNativeValue
+    assert(array(0).asInstanceOf[ MoeNullObject ].getNativeValue === null)
+    assert(array(1).asInstanceOf[ MoeIntObject ].getNativeValue === 10)
+    assert(o.isTrue)
+    assert(!o.isFalse)
+    assert(!o.isUndef)
+  }
 
-    test("... false Array object") {
-        val o = new MoeArrayObject(List())
-        assert(!o.isTrue)
-        assert(o.isFalse)
-        assert(!o.isUndef)
-    }
+  test("... false Array object") {
+    val o = new MoeArrayObject(List())
+    assert(!o.isTrue)
+    assert(o.isFalse)
+    assert(!o.isUndef)
+  }
 
-    test("... complex Array object") {
-        val o = new MoeArrayObject(
-            List(
-                new MoeIntObject(10),
-                new MoeArrayObject(
-                    List(
-                        new MoeIntObject(42)
-                   )
-               )
-           )
-       )
-        val array = o.getNativeValue
-        assert(array(0).asInstanceOf[ MoeIntObject ].getNativeValue === 10)
-        val nested = array(1).asInstanceOf[ MoeArrayObject ].getNativeValue
-        assert(nested(0).asInstanceOf[ MoeIntObject ].getNativeValue === 42)
-        assert(o.isTrue)
-        assert(!o.isFalse)
-        assert(!o.isUndef)
-    }
+  test("... complex Array object") {
+    val o = new MoeArrayObject(
+      List(
+        new MoeIntObject(10),
+        new MoeArrayObject(
+          List(
+            new MoeIntObject(42)
+          )
+        )
+      )
+     )
+    val array = o.getNativeValue
+    assert(array(0).asInstanceOf[ MoeIntObject ].getNativeValue === 10)
+    val nested = array(1).asInstanceOf[ MoeArrayObject ].getNativeValue
+    assert(nested(0).asInstanceOf[ MoeIntObject ].getNativeValue === 42)
+    assert(o.isTrue)
+    assert(!o.isFalse)
+    assert(!o.isUndef)
+  }
 
-    test("... simple Hash object") {
-        val o = new MoeHashObject(
-            HashMap(
-                "foo" -> new MoeNullObject(),
-                "bar" -> new MoeIntObject(10)
-           )
-       )
-        val hash = o.getNativeValue
-        assert(hash("foo").asInstanceOf[ MoeNullObject ].getNativeValue === null)
-        assert(hash("bar").asInstanceOf[ MoeIntObject ].getNativeValue === 10)
-        assert(o.isTrue)
-        assert(!o.isFalse)
-        assert(!o.isUndef)
-    }
+  test("... simple Hash object") {
+    val o = new MoeHashObject(
+      Map(
+        "foo" -> new MoeNullObject(),
+        "bar" -> new MoeIntObject(10)
+      )
+    )
+    val hash = o.getNativeValue
+    assert(hash("foo").asInstanceOf[ MoeNullObject ].getNativeValue === null)
+    assert(hash("bar").asInstanceOf[ MoeIntObject ].getNativeValue === 10)
+    assert(o.isTrue)
+    assert(!o.isFalse)
+    assert(!o.isUndef)
+  }
 
-    test("... false Hash object") {
-        val o = new MoeHashObject(HashMap())
-        assert(!o.isTrue)
-        assert(o.isFalse)
-        assert(!o.isUndef)
-    }
+  test("... false Hash object") {
+    val o = new MoeHashObject(Map())
+    assert(!o.isTrue)
+    assert(o.isFalse)
+    assert(!o.isUndef)
+  }
 
-    test("... complex Hash object") {
-        val o = new MoeHashObject(
-            HashMap(
-                "foo" -> new MoeArrayObject(
-                    List(
-                        new MoeNullObject(),
-                        new MoeIntObject(10)
-                   )
-               ),
-                "bar" -> new MoeIntObject(10)
-           )
-       )
-        val hash = o.getNativeValue
-        assert(hash("bar").asInstanceOf[ MoeIntObject ].getNativeValue === 10)
-        val nested = hash("foo").asInstanceOf[ MoeArrayObject ].getNativeValue
-        assert(nested(0).asInstanceOf[ MoeNullObject ].getNativeValue === null)
-        assert(nested(1).asInstanceOf[ MoeIntObject ].getNativeValue === 10)
-        assert(o.isTrue)
-        assert(!o.isFalse)
-        assert(!o.isUndef)
-    }
+  test("... complex Hash object") {
+    val o = new MoeHashObject(
+      Map(
+        "foo" -> new MoeArrayObject(
+          List(
+            new MoeNullObject(),
+            new MoeIntObject(10)
+          )
+        ),
+        "bar" -> new MoeIntObject(10)
+        )
+    )
+    val hash = o.getNativeValue
+    assert(hash("bar").asInstanceOf[ MoeIntObject ].getNativeValue === 10)
+    val nested = hash("foo").asInstanceOf[ MoeArrayObject ].getNativeValue
+    assert(nested(0).asInstanceOf[ MoeNullObject ].getNativeValue === null)
+    assert(nested(1).asInstanceOf[ MoeIntObject ].getNativeValue === 10)
+    assert(o.isTrue)
+    assert(!o.isFalse)
+    assert(!o.isUndef)
+  }
 
-    test("... simple Pair object") {
-        val o = new MoePairObject("foo" -> new MoeIntObject(10))
-        val pair = o.getNativeValue
-        assert(pair._1 === "foo")
-        assert(pair._2.asInstanceOf[ MoeIntObject ].getNativeValue === 10)
-        assert(o.isTrue)
-        assert(!o.isFalse)
-        assert(!o.isUndef)
-    }
+  test("... simple Pair object") {
+    val o = new MoePairObject("foo" -> new MoeIntObject(10))
+    val pair = o.getNativeValue
+    assert(pair._1 === "foo")
+    assert(pair._2.asInstanceOf[ MoeIntObject ].getNativeValue === 10)
+    assert(o.isTrue)
+    assert(!o.isFalse)
+    assert(!o.isUndef)
+  }
 
 }

--- a/src/test/scala/org/moe/runtime/MoeNativeObjectTestSuite.scala
+++ b/src/test/scala/org/moe/runtime/MoeNativeObjectTestSuite.scala
@@ -38,11 +38,11 @@ class MoeNativeObjectTestSuite extends FunSuite with BeforeAndAfter {
   }
 
   test("... simple Int object") {
-      val o = new MoeIntObject(10)
-      assert(o.getNativeValue === 10)
-      assert(o.isTrue)
-      assert(!o.isFalse)
-      assert(!o.isUndef)
+    val o = new MoeIntObject(10)
+    assert(o.getNativeValue === 10)
+    assert(o.isTrue)
+    assert(!o.isFalse)
+    assert(!o.isUndef)
   }
 
   test("... false Int object") {
@@ -54,27 +54,27 @@ class MoeNativeObjectTestSuite extends FunSuite with BeforeAndAfter {
   }
 
   test("... simple Float object") {
-      val o = new MoeFloatObject(10.5)
-      assert(o.getNativeValue === 10.5)
-      assert(o.isTrue)
-      assert(!o.isFalse)
-      assert(!o.isUndef)
+    val o = new MoeFloatObject(10.5)
+    assert(o.getNativeValue === 10.5)
+    assert(o.isTrue)
+    assert(!o.isFalse)
+    assert(!o.isUndef)
   }
 
   test("... false Float object") {
-      val o = new MoeFloatObject(0.0)
-      assert(o.getNativeValue === 0.0)
-      assert(!o.isTrue)
-      assert(o.isFalse)
-      assert(!o.isUndef)
+    val o = new MoeFloatObject(0.0)
+    assert(o.getNativeValue === 0.0)
+    assert(!o.isTrue)
+    assert(o.isFalse)
+    assert(!o.isUndef)
   }
 
   test("... simple Boolean object") {
-      val o = new MoeBooleanObject(true)
-      assert(o.getNativeValue === true)
-      assert(o.isTrue)
-      assert(!o.isFalse)
-      assert(!o.isUndef)
+    val o = new MoeBooleanObject(true)
+    assert(o.getNativeValue === true)
+    assert(o.isTrue)
+    assert(!o.isFalse)
+    assert(!o.isUndef)
   }
 
   test("... false Boolean object") {

--- a/src/test/scala/org/moe/runtime/MoeOpaqueTestSuite.scala
+++ b/src/test/scala/org/moe/runtime/MoeOpaqueTestSuite.scala
@@ -5,40 +5,40 @@ import org.scalatest.BeforeAndAfter
 
 class MoeOpaqueTestSuite extends FunSuite with BeforeAndAfter {
 
-    var o : MoeOpaque = _
+  var o : MoeOpaque = _
 
-    before {
-        o = new MoeOpaque()
+  before {
+    o = new MoeOpaque()
+  }
+
+  test("... MoeOpaques do not have default values") {
+    assert(!o.hasValue("$.foo"))
+  }
+
+  test("... set a value in the instance") {
+    val c001 = new MoeOpaque()
+    o.setValue("$.foo", c001)
+    assert(o.hasValue("$.foo"))
+    assert(o.getValue("$.foo") === c001)
+  }
+
+  test("... overwrite a value in the instance") {
+    val c001 = new MoeOpaque()
+    val c002 = new MoeOpaque()
+    o.setValue("$.foo", c001)
+    assert(o.hasValue("$.foo"))
+    assert(o.getValue("$.foo") === c001)
+
+    o.setValue("$.foo", c002)
+    assert(o.getValue("$.foo") != c001)
+    assert(o.getValue("$.foo") === c002)
+  }
+
+  test("... instance value not found thrown") {
+    val ex = intercept[Runtime.Errors.InstanceValueNotFound] {
+      o.getValue("$.bar")
     }
-
-    test("... MoeOpaques do not have default values") {
-        assert(!o.hasValue("$.foo"))
-    }
-
-    test("... set a value in the instance") {
-        val c001 = new MoeOpaque()
-        o.setValue("$.foo", c001)
-        assert(o.hasValue("$.foo"))
-        assert(o.getValue("$.foo") === c001)
-    }
-
-    test("... overwrite a value in the instance") {
-        val c001 = new MoeOpaque()
-        val c002 = new MoeOpaque()
-        o.setValue("$.foo", c001)
-        assert(o.hasValue("$.foo"))
-        assert(o.getValue("$.foo") === c001)
-
-        o.setValue("$.foo", c002)
-        assert(o.getValue("$.foo") != c001)
-        assert(o.getValue("$.foo") === c002)
-    }
-
-    test("... instance value not found thrown") {
-        val ex = intercept[Runtime.Errors.InstanceValueNotFound] {
-            o.getValue("$.bar")
-        }
-        assert(ex.getMessage === "$.bar")
-    }
+    assert(ex.getMessage === "$.bar")
+  }
 
 }


### PR DESCRIPTION
- Properly privatize objects associatedClass var
- MoeClass:
  - Ditch overloaded constructors for the implicit one with Option and defaults, then use named params
  - Scaladoc
  - Refactor attribute & method methods to be more idiomatic
- Clean up MoeAttribute
- Show how to document a case class in AST
- Remove the last of the HashMap that were peppered around and unnecessarily mutable
- 2-space indent a bunch of tests that missed the four-space-pocalypse
