### PR TITLE
Fix getAttribute&getMethod to work under inheritance, tests too

### DIFF
--- a/src/main/scala/org/moe/runtime/MoeClass.scala
+++ b/src/main/scala/org/moe/runtime/MoeClass.scala
@@ -64,7 +64,7 @@ class MoeClass (private val name: String) extends MoeObject {
   }
 
   def getAttribute(name: String): MoeAttribute = {
-    if (hasAttribute(name)) return attributes(name)
+    if (attributes.contains(name)) return attributes(name)
     if (hasSuperclass) return superclass.get.getAttribute(name)
     throw new Runtime.Errors.AttributeNotFound(name)
   }
@@ -96,7 +96,7 @@ class MoeClass (private val name: String) extends MoeObject {
   }
 
   def getMethod(name: String): MoeMethod = {
-    if (hasMethod(name)) return methods(name)
+    if (methods.contains(name)) return methods(name)
     if (hasSuperclass) return superclass.get.getMethod(name)
     throw new Runtime.Errors.MethodNotFound(name)
   }

--- a/src/test/scala/org/moe/runtime/MoeClassTestSuite.scala
+++ b/src/test/scala/org/moe/runtime/MoeClassTestSuite.scala
@@ -33,4 +33,39 @@ class MoeClassTestSuite extends FunSuite with BeforeAndAfter {
     assert(obj.callMethod("ident") === obj)
   }
 
+  test("... test method resolution") {
+    val parent = new MoeClass("ParentClass", "0.01", "cpan:STEVAN")
+    val child = new MoeClass("ChildClass", "0.01", "cpan:STEVAN", Some(parent))
+
+    val method = new MoeMethod("ident", (inv, args) => inv)
+    parent.addMethod(method)
+
+    var dad = parent.newInstance
+    var son = child.newInstance
+
+    assert(parent.hasMethod("ident"))
+    assert(child.hasMethod("ident"))
+
+    assert(parent.getMethod("ident") === method)
+    assert(child.getMethod("ident") === method)
+
+    assert(dad.callMethod("ident") === dad)
+    assert(son.callMethod("ident") === son)
+  }
+
+  test("... test attribute resolution") {
+    val parent = new MoeClass("ParentClass", "0.01", "cpan:STEVAN")
+    val child = new MoeClass("ChildClass", "0.01", "cpan:STEVAN", Some(parent))
+
+    val default = new MoeObject()
+    val attr = new MoeAttribute("name", default)
+    parent.addAttribute(attr)
+
+    assert(parent.hasAttribute("name"))
+    assert(child.hasAttribute("name"))
+
+    assert(parent.getAttribute("name") === attr)
+    assert(child.getAttribute("name") === attr)
+  }
+
 }


### PR DESCRIPTION
```
hasMethod and hasAttribute both check whether the method/attribute
exists in the inheritance hierarchy, so we need the local check
here instead. Otherwise when you inherit "foo" then you get an error
on methods("foo").
```
