### PR TITLE
binary, octal and hexadecimal literals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target/
+.ensime
+.ensime_lucene

--- a/src/main/scala/org/moe/parser/Parser.scala
+++ b/src/main/scala/org/moe/parser/Parser.scala
@@ -5,12 +5,16 @@ import scala.util.parsing.combinator._
 import org.moe.ast._
  
 object Parser extends RegexParsers {
-  def intNumber   = """[0-9]+""".r ^^ { n => IntLiteralNode(n.toInt) }
-  def floatNumber = """[0-9]+\.[0-9]+""".r ^^ { n => FloatLiteralNode(n.toDouble) }
+  def intNumber   = """[1-9][0-9_]+""".r ^^ { n => IntLiteralNode(n.replace("_", "").toInt) }
+  def octIntNumber = """0[0-9_]+""".r ^^ { n => IntLiteralNode(Integer.parseInt(n.replace("_", ""), 8)) }
+  def hexIntNumber = """0x[0-9A-Fa-f_]+""".r ^^ { n => IntLiteralNode(Integer.parseInt(n.replace("_", "")
+                                                                      .replace("0x", "").toUpperCase, 16)) }
+  def binIntNumber = """0b[01_]+""".r ^^ { n => IntLiteralNode(Integer.parseInt(n.replace("_", "").replace("0b", ""), 2)) }
+  def floatNumber = """[0-9]*\.[0-9]+""".r ^^ { n => FloatLiteralNode(n.toDouble) }
   def constTrue  : Parser[AST] = "true" ^^ { _ => BooleanLiteralNode(true) }
   def constFalse : Parser[AST] = "false" ^^ { _ => BooleanLiteralNode(false) }
 
-  def literal = floatNumber | intNumber | constTrue | constFalse
+  def literal = floatNumber | intNumber | octIntNumber | hexIntNumber | binIntNumber | constTrue | constFalse
 
   // Parser wrapper -- indicates the start node
   def parseStuff(input: String): AST = parseAll(literal, input) match {

--- a/src/main/scala/org/moe/parser/Parser.scala
+++ b/src/main/scala/org/moe/parser/Parser.scala
@@ -10,7 +10,7 @@ object Parser extends RegexParsers {
   def hexIntNumber = """0x[0-9A-Fa-f_]+""".r ^^ { n => IntLiteralNode(Integer.parseInt(n.replace("_", "")
                                                                       .replace("0x", "").toUpperCase, 16)) }
   def binIntNumber = """0b[01_]+""".r ^^ { n => IntLiteralNode(Integer.parseInt(n.replace("_", "").replace("0b", ""), 2)) }
-  def floatNumber = """[0-9]*\.[0-9]+""".r ^^ { n => FloatLiteralNode(n.toDouble) }
+  def floatNumber = """[0-9_]*\.[0-9_]+""".r ^^ { n => FloatLiteralNode(n.replace("_", "").toDouble) }
   def constTrue  : Parser[AST] = "true" ^^ { _ => BooleanLiteralNode(true) }
   def constFalse : Parser[AST] = "false" ^^ { _ => BooleanLiteralNode(false) }
 

--- a/src/test/scala/org/moe/parser/ParserTestSuite.scala
+++ b/src/test/scala/org/moe/parser/ParserTestSuite.scala
@@ -19,10 +19,40 @@ class ParserTestSuite extends FunSuite with BeforeAndAfter {
     assert(result.asInstanceOf[MoeIntObject].getNativeValue === 123)
   }
 
+  test("... basic test with an octal int") {
+    val ast = basicAST(List(Parser.parseStuff("0123")))
+    val result = Interpreter.eval(Runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeIntObject].getNativeValue === 83)
+  }
+
+  test("... basic test with an hexadecimal int") {
+    val ast = basicAST(List(Parser.parseStuff("0x123")))
+    val result = Interpreter.eval(Runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeIntObject].getNativeValue === 0x123)
+  }
+
+  test("... basic test with an hexadecimal int - 2") {
+    val ast = basicAST(List(Parser.parseStuff("0xFFFF")))
+    val result = Interpreter.eval(Runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeIntObject].getNativeValue === 0xFFFF)
+  }
+
+  test("... basic test with an binary int literal") {
+    val ast = basicAST(List(Parser.parseStuff("0b10110")))
+    val result = Interpreter.eval(Runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeIntObject].getNativeValue === 22)
+  }
+
   test("... basic test with a float") {
     val ast = basicAST(List(Parser.parseStuff("123.5")))
     val result = Interpreter.eval(Runtime.getRootEnv, ast)
     assert(result.asInstanceOf[MoeFloatObject].getNativeValue === 123.5)
+  }
+
+  test("... basic test with a float - 2") {
+    val ast = basicAST(List(Parser.parseStuff(".5678")))
+    val result = Interpreter.eval(Runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeFloatObject].getNativeValue === .5678)
   }
 
   test("... basic test with a true") {

--- a/src/test/scala/org/moe/parser/ParserTestSuite.scala
+++ b/src/test/scala/org/moe/parser/ParserTestSuite.scala
@@ -19,10 +19,22 @@ class ParserTestSuite extends FunSuite with BeforeAndAfter {
     assert(result.asInstanceOf[MoeIntObject].getNativeValue === 123)
   }
 
+  test("... basic test with an int - embedded underscore") {
+    val ast = basicAST(List(Parser.parseStuff("123_456")))
+    val result = Interpreter.eval(Runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeIntObject].getNativeValue === 123456)
+  }
+
   test("... basic test with an octal int") {
     val ast = basicAST(List(Parser.parseStuff("0123")))
     val result = Interpreter.eval(Runtime.getRootEnv, ast)
     assert(result.asInstanceOf[MoeIntObject].getNativeValue === 83)
+  }
+
+  test("... basic test with an octal int - embedded underscore") {
+    val ast = basicAST(List(Parser.parseStuff("0123_456")))
+    val result = Interpreter.eval(Runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeIntObject].getNativeValue === 42798)
   }
 
   test("... basic test with an hexadecimal int") {
@@ -37,10 +49,28 @@ class ParserTestSuite extends FunSuite with BeforeAndAfter {
     assert(result.asInstanceOf[MoeIntObject].getNativeValue === 0xFFFF)
   }
 
+  test("... basic test with an hexadecimal int - embedded underscore") {
+    val ast = basicAST(List(Parser.parseStuff("0x123_456")))
+    val result = Interpreter.eval(Runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeIntObject].getNativeValue === 0x123456)
+  }
+
+  test("... basic test with an hexadecimal int - embedded underscore - 2") {
+    val ast = basicAST(List(Parser.parseStuff("0xAB_CDEF")))
+    val result = Interpreter.eval(Runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeIntObject].getNativeValue === 0xABCDEF)
+  }
+
   test("... basic test with an binary int literal") {
     val ast = basicAST(List(Parser.parseStuff("0b10110")))
     val result = Interpreter.eval(Runtime.getRootEnv, ast)
     assert(result.asInstanceOf[MoeIntObject].getNativeValue === 22)
+  }
+
+  test("... basic test with an binary int literal - embedded underscore") {
+    val ast = basicAST(List(Parser.parseStuff("0b1011_0110")))
+    val result = Interpreter.eval(Runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeIntObject].getNativeValue === 182)
   }
 
   test("... basic test with a float") {
@@ -53,6 +83,12 @@ class ParserTestSuite extends FunSuite with BeforeAndAfter {
     val ast = basicAST(List(Parser.parseStuff(".5678")))
     val result = Interpreter.eval(Runtime.getRootEnv, ast)
     assert(result.asInstanceOf[MoeFloatObject].getNativeValue === .5678)
+  }
+
+  test("... basic test with a float - embedded underscore") {
+    val ast = basicAST(List(Parser.parseStuff("123_456.56_789")))
+    val result = Interpreter.eval(Runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeFloatObject].getNativeValue === 123456.56789)
   }
 
   test("... basic test with a true") {


### PR DESCRIPTION
Also, embedded underscores in literals are supported.

Note: I am a Scala newbie, so there might very well be a better way than what I did.
