### PR TITLE
prefix vs. postfix increment and decrement

### DIFF
--- a/src/main/scala/org/moe/ast/AST.scala
+++ b/src/main/scala/org/moe/ast/AST.scala
@@ -38,8 +38,8 @@ case class RangeLiteralNode(start: AST, end: AST) extends AST
 
 // unary operators
 
-case class IncrementNode(receiver: AST, prefix: Boolean = false) extends AST
-case class DecrementNode(receiver: AST, prefix: Boolean = false) extends AST
+case class IncrementNode(receiver: AST, is_prefix: Boolean = false) extends AST
+case class DecrementNode(receiver: AST, is_prefix: Boolean = false) extends AST
 case class NotNode(receiver: AST) extends AST
 
 

--- a/src/main/scala/org/moe/ast/AST.scala
+++ b/src/main/scala/org/moe/ast/AST.scala
@@ -38,8 +38,8 @@ case class RangeLiteralNode(start: AST, end: AST) extends AST
 
 // unary operators
 
-case class IncrementNode(receiver: AST) extends AST
-case class DecrementNode(receiver: AST) extends AST
+case class IncrementNode(receiver: AST, prefix: Boolean = false) extends AST
+case class DecrementNode(receiver: AST, prefix: Boolean = false) extends AST
 case class NotNode(receiver: AST) extends AST
 
 

--- a/src/main/scala/org/moe/ast/Serializer.scala
+++ b/src/main/scala/org/moe/ast/Serializer.scala
@@ -41,8 +41,9 @@ object Serializer {
       )
     )
 
-    case IncrementNode(receiver) => JSONObject(Map("IncrementNode" -> toJSON(receiver)))
-    case DecrementNode(receiver) => JSONObject(Map("DecrementNode" -> toJSON(receiver)))
+    // TODO we should probably be storing the "prefix" in the serialized JSON (not sure how to do that)
+    case IncrementNode(receiver, prefix) => JSONObject(Map("IncrementNode" -> toJSON(receiver)))
+    case DecrementNode(receiver, prefix) => JSONObject(Map("DecrementNode" -> toJSON(receiver)))
     case NotNode(receiver)       => JSONObject(Map("NotNode" -> toJSON(receiver)))
 
     case AndNode(lhs, rhs) => JSONObject(

--- a/src/main/scala/org/moe/ast/Serializer.scala
+++ b/src/main/scala/org/moe/ast/Serializer.scala
@@ -41,10 +41,10 @@ object Serializer {
       )
     )
 
-    // TODO we should probably be storing the "prefix" in the serialized JSON (not sure how to do that)
-    case IncrementNode(receiver, prefix) => JSONObject(Map("IncrementNode" -> toJSON(receiver)))
-    case DecrementNode(receiver, prefix) => JSONObject(Map("DecrementNode" -> toJSON(receiver)))
-    case NotNode(receiver)       => JSONObject(Map("NotNode" -> toJSON(receiver)))
+    // TODO we should probably be storing the "is_prefix" in the serialized JSON (not sure how to do that)
+    case IncrementNode(receiver, is_prefix) => JSONObject(Map("IncrementNode" -> toJSON(receiver)))
+    case DecrementNode(receiver, is_prefix) => JSONObject(Map("DecrementNode" -> toJSON(receiver)))
+    case NotNode(receiver)                  => JSONObject(Map("NotNode" -> toJSON(receiver)))
 
     case AndNode(lhs, rhs) => JSONObject(
       Map(

--- a/src/main/scala/org/moe/interpreter/Interpreter.scala
+++ b/src/main/scala/org/moe/interpreter/Interpreter.scala
@@ -146,35 +146,35 @@ object Interpreter {
 
       // unary operators
 
-      case IncrementNode(receiver: AST, prefix) => receiver match {
+      case IncrementNode(receiver: AST, is_prefix) => receiver match {
         case VariableAccessNode(varName) => env.get(varName).getOrElse(
           throw new MoeErrors.VariableNotFound(varName)
         ) match {
           case i: MoeIntObject => {
             val new_i = runtime.NativeObjects.getInt(i.getNativeValue + 1)
             env.set(varName, new_i)
-            if (prefix) new_i else i
+            if (is_prefix) new_i else i
           }
           case n: MoeFloatObject => {
             val new_n = runtime.NativeObjects.getFloat(n.getNativeValue + 1.0)
             env.set(varName, new_n)
-            if (prefix) new_n else n
+            if (is_prefix) new_n else n
           }
         }
       }
-      case DecrementNode(receiver: AST, prefix) => receiver match {
+      case DecrementNode(receiver: AST, is_prefix) => receiver match {
         case VariableAccessNode(varName) => env.get(varName).getOrElse(
           throw new MoeErrors.VariableNotFound(varName)
         ) match {
           case i: MoeIntObject => {
             val new_i = runtime.NativeObjects.getInt(i.getNativeValue - 1)
             env.set(varName, new_i)
-            if (prefix) new_i else i
+            if (is_prefix) new_i else i
           }
           case n: MoeFloatObject => {
             val new_n = runtime.NativeObjects.getFloat(n.getNativeValue - 1.0)
             env.set(varName, new_n)
-            if (prefix) new_n else n
+            if (is_prefix) new_n else n
           }
         }
       }

--- a/src/main/scala/org/moe/interpreter/Interpreter.scala
+++ b/src/main/scala/org/moe/interpreter/Interpreter.scala
@@ -146,27 +146,51 @@ object Interpreter {
 
       // unary operators
 
-      case IncrementNode(receiver: AST) => receiver match {
+      case IncrementNode(receiver: AST, prefix) => receiver match {
         case VariableAccessNode(varName) => env.get(varName).getOrElse(
           throw new MoeErrors.VariableNotFound(varName)
         ) match {
           case i: MoeIntObject => {
-            env.set(varName, runtime.NativeObjects.getInt(i.getNativeValue + 1)).get
+            val new_i = runtime.NativeObjects.getInt(i.getNativeValue + 1)
+            env.set(varName, new_i)
+            if (prefix) {
+              new_i
+            } else {
+              i
+            }
           }
           case n: MoeFloatObject => {
-            env.set(varName, runtime.NativeObjects.getFloat(n.getNativeValue + 1.0)).get
+            val new_n = runtime.NativeObjects.getFloat(n.getNativeValue + 1.0)
+            env.set(varName, new_n)
+            if (prefix) {
+              new_n
+            } else {
+              n
+            }
           }
         }
       }
-      case DecrementNode(receiver: AST) => receiver match {
+      case DecrementNode(receiver: AST, prefix) => receiver match {
         case VariableAccessNode(varName) => env.get(varName).getOrElse(
           throw new MoeErrors.VariableNotFound(varName)
         ) match {
           case i: MoeIntObject => {
-            env.set(varName, runtime.NativeObjects.getInt(i.getNativeValue - 1)).get
+            val new_i = runtime.NativeObjects.getInt(i.getNativeValue - 1)
+            env.set(varName, new_i)
+            if (prefix) {
+              new_i
+            } else {
+              i
+            }
           }
           case n: MoeFloatObject => {
-            env.set(varName, runtime.NativeObjects.getFloat(n.getNativeValue - 1.0)).get
+            val new_n = runtime.NativeObjects.getFloat(n.getNativeValue - 1.0)
+            env.set(varName, new_n)
+            if (prefix) {
+              new_n
+            } else {
+              n
+            }
           }
         }
       }

--- a/src/main/scala/org/moe/interpreter/Interpreter.scala
+++ b/src/main/scala/org/moe/interpreter/Interpreter.scala
@@ -153,20 +153,12 @@ object Interpreter {
           case i: MoeIntObject => {
             val new_i = runtime.NativeObjects.getInt(i.getNativeValue + 1)
             env.set(varName, new_i)
-            if (prefix) {
-              new_i
-            } else {
-              i
-            }
+            if (prefix) new_i else i
           }
           case n: MoeFloatObject => {
             val new_n = runtime.NativeObjects.getFloat(n.getNativeValue + 1.0)
             env.set(varName, new_n)
-            if (prefix) {
-              new_n
-            } else {
-              n
-            }
+            if (prefix) new_n else n
           }
         }
       }
@@ -177,20 +169,12 @@ object Interpreter {
           case i: MoeIntObject => {
             val new_i = runtime.NativeObjects.getInt(i.getNativeValue - 1)
             env.set(varName, new_i)
-            if (prefix) {
-              new_i
-            } else {
-              i
-            }
+            if (prefix) new_i else i
           }
           case n: MoeFloatObject => {
             val new_n = runtime.NativeObjects.getFloat(n.getNativeValue - 1.0)
             env.set(varName, new_n)
-            if (prefix) {
-              new_n
-            } else {
-              n
-            }
+            if (prefix) new_n else n
           }
         }
       }

--- a/src/test/scala/org/moe/interpreter/IncrementDecrementNodeTestSuite.scala
+++ b/src/test/scala/org/moe/interpreter/IncrementDecrementNodeTestSuite.scala
@@ -7,21 +7,83 @@ import org.moe.ast._
 
 class IncrementDecrementNodeTestSuite extends FunSuite with InterpreterTestUtils {
 
-  test("... basic test with variable increment") {
+// integer post-increment tests
+  test("... basic test with variable post-increment") {
     val ast = wrapSimpleAST(
       List(
         VariableDeclarationNode(
           "$foo",
           IntLiteralNode(42)
         ),
-        IncrementNode(VariableAccessNode("$foo"))
+        IncrementNode(VariableAccessNode("$foo")),
+        VariableAccessNode("$foo")
       )
     )
     val result = Interpreter.eval(runtime, runtime.getRootEnv, ast)
     assert(result.asInstanceOf[MoeIntObject].getNativeValue === 43)
   }
 
-  test("... basic test with variable increment (float)") {
+  test("... variable post-increment return value") {
+    val ast = wrapSimpleAST(
+      List(
+        VariableDeclarationNode(
+          "$foo",
+          IntLiteralNode(42)
+        ),
+        IncrementNode(VariableAccessNode("$foo"))
+      )
+    )
+    val result = Interpreter.eval(runtime, runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeIntObject].getNativeValue === 42)
+  }
+
+// integer pre-increment tests
+  test("... basic test with variable pre-increment") {
+    val ast = wrapSimpleAST(
+      List(
+        VariableDeclarationNode(
+          "$foo",
+          IntLiteralNode(42)
+        ),
+        IncrementNode(VariableAccessNode("$foo"), true),
+        VariableAccessNode("$foo")
+      )
+    )
+    val result = Interpreter.eval(runtime, runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeIntObject].getNativeValue === 43)
+  }
+
+  test("... variable pre-increment return value") {
+    val ast = wrapSimpleAST(
+      List(
+        VariableDeclarationNode(
+          "$foo",
+          IntLiteralNode(42)
+        ),
+        IncrementNode(VariableAccessNode("$foo"),true)
+      )
+    )
+    val result = Interpreter.eval(runtime, runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeIntObject].getNativeValue === 43)
+  }
+
+// float post-increment tests
+  test("... basic test with variable post-increment (float)") {
+    val ast = wrapSimpleAST(
+      List(
+        VariableDeclarationNode(
+          "$foo",
+          FloatLiteralNode(98.6)
+        ),
+        IncrementNode(VariableAccessNode("$foo")),
+        VariableAccessNode("$foo")
+      )
+    )
+    val result = Interpreter.eval(runtime, runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeFloatObject].getNativeValue === 99.6)
+  }
+
+  test("... variable post-increment return value (float)") {
     val ast = wrapSimpleAST(
       List(
         VariableDeclarationNode(
@@ -32,10 +94,56 @@ class IncrementDecrementNodeTestSuite extends FunSuite with InterpreterTestUtils
       )
     )
     val result = Interpreter.eval(runtime, runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeFloatObject].getNativeValue === 98.6)
+  }
+
+// float pre-increment tests
+  test("... basic test with variable pre-increment (float)") {
+    val ast = wrapSimpleAST(
+      List(
+        VariableDeclarationNode(
+          "$foo",
+          FloatLiteralNode(98.6)
+        ),
+        IncrementNode(VariableAccessNode("$foo"), true),
+        VariableAccessNode("$foo")
+      )
+    )
+    val result = Interpreter.eval(runtime, runtime.getRootEnv, ast)
     assert(result.asInstanceOf[MoeFloatObject].getNativeValue === 99.6)
   }
 
-  test("... basic test with variable decrement") {
+  test("... variable pre-increment return value (float)") {
+    val ast = wrapSimpleAST(
+      List(
+        VariableDeclarationNode(
+          "$foo",
+          FloatLiteralNode(98.6)
+        ),
+        IncrementNode(VariableAccessNode("$foo"), true)
+      )
+    )
+    val result = Interpreter.eval(runtime, runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeFloatObject].getNativeValue === 99.6)
+  }
+
+// integer post-decrement tests
+  test("... basic test with variable post-decrement") {
+    val ast = wrapSimpleAST(
+      List(
+        VariableDeclarationNode(
+          "$foo",
+          IntLiteralNode(42)
+        ),
+        DecrementNode(VariableAccessNode("$foo")),
+        VariableAccessNode("$foo")
+      )
+    )
+    val result = Interpreter.eval(runtime, runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeIntObject].getNativeValue === 41)
+  }
+
+  test("... variable post-decrement return value") {
     val ast = wrapSimpleAST(
       List(
         VariableDeclarationNode(
@@ -46,10 +154,56 @@ class IncrementDecrementNodeTestSuite extends FunSuite with InterpreterTestUtils
       )
     )
     val result = Interpreter.eval(runtime, runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeIntObject].getNativeValue === 42)
+  }
+
+// integer pre-decrement tests
+  test("... basic test with variable pre-decrement") {
+    val ast = wrapSimpleAST(
+      List(
+        VariableDeclarationNode(
+          "$foo",
+          IntLiteralNode(42)
+        ),
+        DecrementNode(VariableAccessNode("$foo"), true),
+        VariableAccessNode("$foo")
+      )
+    )
+    val result = Interpreter.eval(runtime, runtime.getRootEnv, ast)
     assert(result.asInstanceOf[MoeIntObject].getNativeValue === 41)
   }
 
-  test("... basic test with variable decrement (float)") {
+  test("... variable pre-decrement return value") {
+    val ast = wrapSimpleAST(
+      List(
+        VariableDeclarationNode(
+          "$foo",
+          IntLiteralNode(42)
+        ),
+        DecrementNode(VariableAccessNode("$foo"),true)
+      )
+    )
+    val result = Interpreter.eval(runtime, runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeIntObject].getNativeValue === 41)
+  }
+
+// float post-decrement tests
+  test("... basic test with variable post-decrement (float)") {
+    val ast = wrapSimpleAST(
+      List(
+        VariableDeclarationNode(
+          "$foo",
+          FloatLiteralNode(98.6)
+        ),
+        DecrementNode(VariableAccessNode("$foo")),
+        VariableAccessNode("$foo")
+      )
+    )
+    val result = Interpreter.eval(runtime, runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeFloatObject].getNativeValue === 97.6)
+  }
+
+  test("... variable post-decrement return value (float)") {
     val ast = wrapSimpleAST(
       List(
         VariableDeclarationNode(
@@ -57,6 +211,36 @@ class IncrementDecrementNodeTestSuite extends FunSuite with InterpreterTestUtils
           FloatLiteralNode(98.6)
         ),
         DecrementNode(VariableAccessNode("$foo"))
+      )
+    )
+    val result = Interpreter.eval(runtime, runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeFloatObject].getNativeValue === 98.6)
+  }
+
+// float pre-decrement tests
+  test("... basic test with variable pre-decrement (float)") {
+    val ast = wrapSimpleAST(
+      List(
+        VariableDeclarationNode(
+          "$foo",
+          FloatLiteralNode(98.6)
+        ),
+        DecrementNode(VariableAccessNode("$foo"), true),
+        VariableAccessNode("$foo")
+      )
+    )
+    val result = Interpreter.eval(runtime, runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeFloatObject].getNativeValue === 97.6)
+  }
+
+  test("... variable pre-decrement return value (float)") {
+    val ast = wrapSimpleAST(
+      List(
+        VariableDeclarationNode(
+          "$foo",
+          FloatLiteralNode(98.6)
+        ),
+        DecrementNode(VariableAccessNode("$foo"), true)
       )
     )
     val result = Interpreter.eval(runtime, runtime.getRootEnv, ast)


### PR DESCRIPTION
The return value of $foo++ is different than ++$foo.  Likewise, $foo--
vs. --$foo.  This commit adds support for differentiating the two modes
(prefix vs. postfix).

Also, please be gentle.  This is the first Scala code I've written :)
