### PR TITLE
Rudimentary support for string ranges

### DIFF
--- a/src/main/scala/org/moe/interpreter/Interpreter.scala
+++ b/src/main/scala/org/moe/interpreter/Interpreter.scala
@@ -41,7 +41,10 @@ object Interpreter {
     import scala.util.matching.Regex
 
     def magicalStringIncrement(str: String): String = {
-      def incr_numeric_part(n: String) = (n.toInt + 1).toString
+      def incr_numeric_part(n: String) = {
+        val len = n.length
+        ("%0" + len + "d").format(n.toInt + 1).toString
+      }
 
       def incr_alpha_part(s: String) = {
 

--- a/src/main/scala/org/moe/interpreter/Interpreter.scala
+++ b/src/main/scala/org/moe/interpreter/Interpreter.scala
@@ -34,6 +34,61 @@ object Interpreter {
 
       body(env)
     }
+
+    // strings matching the alphanumeric pattern /^[a-zA-Z]*[0-9]*\z/
+    // are incrementable
+
+    import scala.util.matching.Regex
+
+    def magicalStringIncrement(str: String): String = {
+      def incr_numeric_part(n: String) = (n.toInt + 1).toString
+
+      def incr_alpha_part(s: String) = {
+
+        def succ(c: Char, carry: Boolean): (Char, Boolean) = {
+          if (carry)
+            c match {
+              case 'z' => ('a', true)
+              case 'Z' => ('A', true)
+              case _   => ((c.toInt + 1).toChar, false)
+            }
+          else
+            (c, false)
+        }
+
+        var carry = true
+        val incremented = (for (c <- s.reverse) yield {
+          val succ_c = succ(c, carry)
+          carry = succ_c._2
+          succ_c._1
+        }).reverse
+        (if (carry) (incremented.head.toString ++ incremented) else incremented).mkString
+      }
+
+      def increment_in_parts(alpha: String, numeric: String) = {
+        if (alpha.isEmpty) {
+          // no alpha prefix; increment as numeric
+          incr_numeric_part(numeric)
+        } else if (numeric.isEmpty) {
+          // only alpha part
+          incr_alpha_part(alpha)
+        } else {
+          // both alpha and numeric parts exist. increment numeric
+          // part first; if it carries over then increment alpha part
+          val next_n = incr_numeric_part(numeric)
+          if (next_n.length == numeric.length)
+            alpha + next_n
+          else
+            incr_alpha_part(alpha) + next_n.tail
+        }
+      }
+
+      val alpha_numeric = """^([a-zA-Z]*)([0-9]*)\z""".r
+      str match {
+        case alpha_numeric(alpha, numeric) => increment_in_parts(alpha, numeric)
+        case _ => throw new MoeErrors.MoeException("string is not incrementable")
+      }
+    }
   }
 
   def eval(runtime: MoeRuntime, env: MoeEnvironment, node: AST): MoeObject = {
@@ -179,6 +234,9 @@ object Interpreter {
           }
           case n: MoeFloatObject => {
             env.set(varName, runtime.NativeObjects.getFloat(n.getNativeValue + 1.0)).get
+          }
+          case s: MoeStringObject => {
+            env.set(varName, runtime.NativeObjects.getString(Utils.magicalStringIncrement(s.getNativeValue))).get
           }
         }
       }

--- a/src/main/scala/org/moe/interpreter/Interpreter.scala
+++ b/src/main/scala/org/moe/interpreter/Interpreter.scala
@@ -209,18 +209,17 @@ object Interpreter {
             val range_start = Utils.objToString(s)
             val range_end   = Utils.objToString(e)
 
-            // return the successor of the string ("abc" => "abd")
-            def succ(str: String) = str.init + (str.last.toInt + 1).toChar
-
-            // this is totally non-functional, imperative style code,
-            // not in Scala spirit; but will do, for now
-            var elems: List[String] = List()
-            var str = range_start
-            while (str <= range_end) {
-              elems = elems :+ str
-              str = succ(str)
+            if (range_start.length > range_end.length)
+              runtime.NativeObjects.getArray()
+            else {
+              var elems: List[String] = List()
+              var str = range_start
+              while (str <= range_end || str.length < range_end.length) {
+                elems = elems :+ str
+                str = Utils.magicalStringIncrement(str)
+              }
+              runtime.NativeObjects.getArray(elems.map(runtime.NativeObjects.getString(_)))
             }
-            runtime.NativeObjects.getArray(elems.map(runtime.NativeObjects.getString(_)))
           }
           case _ => throw new MoeErrors.UnexpectedType("Pair of MoeIntObject or MoeStringObject expected")
         }

--- a/src/test/scala/org/moe/interpreter/IncrementDecrementNodeTestSuite.scala
+++ b/src/test/scala/org/moe/interpreter/IncrementDecrementNodeTestSuite.scala
@@ -63,4 +63,88 @@ class IncrementDecrementNodeTestSuite extends FunSuite with InterpreterTestUtils
     assert(result.asInstanceOf[MoeFloatObject].getNativeValue === 97.6)
   }
 
+  test("... basic test with variable increment (string)") {
+    val ast = wrapSimpleAST(
+      List(
+        VariableDeclarationNode(
+          "$foo",
+          StringLiteralNode("123")
+        ),
+        IncrementNode(VariableAccessNode("$foo"))
+      )
+    )
+    val result = Interpreter.eval(runtime, runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeStringObject].getNativeValue === "124")
+  }
+
+  test("... basic test with variable increment (string) #2") {
+    val ast = wrapSimpleAST(
+      List(
+        VariableDeclarationNode(
+          "$foo",
+          StringLiteralNode("99")
+        ),
+        IncrementNode(VariableAccessNode("$foo"))
+      )
+    )
+    val result = Interpreter.eval(runtime, runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeStringObject].getNativeValue === "100")
+  }
+
+  test("... basic test with variable increment (string) #3") {
+    val ast = wrapSimpleAST(
+      List(
+        VariableDeclarationNode(
+          "$foo",
+          StringLiteralNode("99")
+        ),
+        IncrementNode(VariableAccessNode("$foo"))
+      )
+    )
+    val result = Interpreter.eval(runtime, runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeStringObject].getNativeValue === "100")
+  }
+
+  test("... basic test with variable increment (string) #4") {
+    val ast = wrapSimpleAST(
+      List(
+        VariableDeclarationNode(
+          "$foo",
+          StringLiteralNode("a0")
+        ),
+        IncrementNode(VariableAccessNode("$foo"))
+      )
+    )
+    val result = Interpreter.eval(runtime, runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeStringObject].getNativeValue === "a1")
+  }
+
+  test("... basic test with variable increment (string) #5") {
+    val ast = wrapSimpleAST(
+      List(
+        VariableDeclarationNode(
+          "$foo",
+          StringLiteralNode("Az")
+        ),
+        IncrementNode(VariableAccessNode("$foo"))
+      )
+    )
+    val result = Interpreter.eval(runtime, runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeStringObject].getNativeValue === "Ba")
+  }
+
+  test("... basic test with variable increment (string) #6") {
+    val ast = wrapSimpleAST(
+      List(
+        VariableDeclarationNode(
+          "$foo",
+          StringLiteralNode("zz")
+        ),
+        IncrementNode(VariableAccessNode("$foo"))
+      )
+    )
+    val result = Interpreter.eval(runtime, runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeStringObject].getNativeValue === "aaa")
+  }
+
 }

--- a/src/test/scala/org/moe/interpreter/IncrementDecrementNodeTestSuite.scala
+++ b/src/test/scala/org/moe/interpreter/IncrementDecrementNodeTestSuite.scala
@@ -147,4 +147,18 @@ class IncrementDecrementNodeTestSuite extends FunSuite with InterpreterTestUtils
     assert(result.asInstanceOf[MoeStringObject].getNativeValue === "aaa")
   }
 
+  test("... basic test with variable increment (string) #7") {
+    val ast = wrapSimpleAST(
+      List(
+        VariableDeclarationNode(
+          "$foo",
+          StringLiteralNode("01")
+        ),
+        IncrementNode(VariableAccessNode("$foo"))
+      )
+    )
+    val result = Interpreter.eval(runtime, runtime.getRootEnv, ast)
+    assert(result.asInstanceOf[MoeStringObject].getNativeValue === "02")
+  }
+
 }

--- a/src/test/scala/org/moe/interpreter/RangeLiteralNodeTestSuite.scala
+++ b/src/test/scala/org/moe/interpreter/RangeLiteralNodeTestSuite.scala
@@ -7,7 +7,7 @@ import org.scalatest.FunSuite
 
 class RangeLiteralNodeTestSuite extends FunSuite with InterpreterTestUtils {
 
-  test("... basic test with Range") {
+  test("... basic test with Integer Range") {
     val ast = wrapSimpleAST(
       List(
         RangeLiteralNode(
@@ -24,6 +24,25 @@ class RangeLiteralNodeTestSuite extends FunSuite with InterpreterTestUtils {
     assert(array(0).asInstanceOf[MoeIntObject].getNativeValue === 1)
     assert(array(1).asInstanceOf[MoeIntObject].getNativeValue === 2)
     assert(array(2).asInstanceOf[MoeIntObject].getNativeValue === 3)
+  }
+
+  test("... basic test with String Range") {
+    val ast = wrapSimpleAST(
+      List(
+        RangeLiteralNode(
+          StringLiteralNode("a"),
+          StringLiteralNode("c")
+        )
+      )
+    )
+    val result = Interpreter.eval(runtime, runtime.getRootEnv, ast)
+
+    val array: List[MoeObject] = result.asInstanceOf[MoeArrayObject].getNativeValue
+
+    assert(array.size === 3)
+    assert(array(0).asInstanceOf[MoeStringObject].getNativeValue === "a")
+    assert(array(1).asInstanceOf[MoeStringObject].getNativeValue === "b")
+    assert(array(2).asInstanceOf[MoeStringObject].getNativeValue === "c")
   }
 
 }

--- a/src/test/scala/org/moe/parser/RangeLiteralTestSuite.scala
+++ b/src/test/scala/org/moe/parser/RangeLiteralTestSuite.scala
@@ -10,7 +10,7 @@ import org.moe.parser._
 
 class RangeLiteralTestSuite extends FunSuite with BeforeAndAfter with ParserTestUtils {
 
-  test("... basic test with a simple range") {
+  test("... basic test with a simple integer range") {
     val result = interpretCode("1 .. 3")
 
     val array: List[MoeObject] = result.asInstanceOf[MoeArrayObject].getNativeValue
@@ -19,6 +19,17 @@ class RangeLiteralTestSuite extends FunSuite with BeforeAndAfter with ParserTest
     assert(array(0).asInstanceOf[MoeIntObject].getNativeValue === 1)
     assert(array(1).asInstanceOf[MoeIntObject].getNativeValue === 2)
     assert(array(2).asInstanceOf[MoeIntObject].getNativeValue === 3)
+  }
+
+  test("... basic test with a simple string range") {
+    val result = interpretCode(""" "a" .. "c" """)
+
+    val array: List[MoeObject] = result.asInstanceOf[MoeArrayObject].getNativeValue
+
+    assert(array.size === 3)
+    assert(array(0).asInstanceOf[MoeStringObject].getNativeValue === "a")
+    assert(array(1).asInstanceOf[MoeStringObject].getNativeValue === "b")
+    assert(array(2).asInstanceOf[MoeStringObject].getNativeValue === "c")
   }
 
 }

--- a/src/test/scala/org/moe/parser/RangeLiteralTestSuite.scala
+++ b/src/test/scala/org/moe/parser/RangeLiteralTestSuite.scala
@@ -21,7 +21,40 @@ class RangeLiteralTestSuite extends FunSuite with BeforeAndAfter with ParserTest
     assert(array(2).asInstanceOf[MoeIntObject].getNativeValue === 3)
   }
 
-  test("... basic test with a simple string range") {
+  test("... basic test with a simple string range #1") {
+    val result = interpretCode(""" "1" .. "3" """)
+
+    val array: List[MoeObject] = result.asInstanceOf[MoeArrayObject].getNativeValue
+
+    assert(array.size === 3)
+    assert(array(0).asInstanceOf[MoeStringObject].getNativeValue === "1")
+    assert(array(1).asInstanceOf[MoeStringObject].getNativeValue === "2")
+    assert(array(2).asInstanceOf[MoeStringObject].getNativeValue === "3")
+  }
+
+  test("... basic test with a simple string range #2") {
+    val result = interpretCode(""" "01" .. "03" """)
+
+    val array: List[MoeObject] = result.asInstanceOf[MoeArrayObject].getNativeValue
+
+    assert(array.size === 3)
+    assert(array(0).asInstanceOf[MoeStringObject].getNativeValue === "01")
+    assert(array(1).asInstanceOf[MoeStringObject].getNativeValue === "02")
+    assert(array(2).asInstanceOf[MoeStringObject].getNativeValue === "03")
+  }
+
+  test("... basic test with a simple string range #3") {
+    val result = interpretCode(""" "1" .. "3" """)
+
+    val array: List[MoeObject] = result.asInstanceOf[MoeArrayObject].getNativeValue
+
+    assert(array.size === 3)
+    assert(array(0).asInstanceOf[MoeStringObject].getNativeValue === "1")
+    assert(array(1).asInstanceOf[MoeStringObject].getNativeValue === "2")
+    assert(array(2).asInstanceOf[MoeStringObject].getNativeValue === "3")
+  }
+
+  test("... basic test with a simple string range #4") {
     val result = interpretCode(""" "a" .. "c" """)
 
     val array: List[MoeObject] = result.asInstanceOf[MoeArrayObject].getNativeValue
@@ -30,6 +63,33 @@ class RangeLiteralTestSuite extends FunSuite with BeforeAndAfter with ParserTest
     assert(array(0).asInstanceOf[MoeStringObject].getNativeValue === "a")
     assert(array(1).asInstanceOf[MoeStringObject].getNativeValue === "b")
     assert(array(2).asInstanceOf[MoeStringObject].getNativeValue === "c")
+  }
+
+  test("... basic test with a simple string range #5") {
+    val result = interpretCode(""" "z" .. "ab" """)
+
+    val array: List[MoeObject] = result.asInstanceOf[MoeArrayObject].getNativeValue
+
+    assert(array.size === 3)
+    assert(array(0).asInstanceOf[MoeStringObject].getNativeValue === "z")
+    assert(array(1).asInstanceOf[MoeStringObject].getNativeValue === "aa")
+    assert(array(2).asInstanceOf[MoeStringObject].getNativeValue === "ab")
+  }
+
+  test("... basic test with a simple string range #6") {
+    val result = interpretCode(""" "ab" .. "z" """)
+
+    val array: List[MoeObject] = result.asInstanceOf[MoeArrayObject].getNativeValue
+
+    assert(array.size === 0)
+  }
+
+  test("... basic test with a simple string range #7") {
+    val result = interpretCode(""" "zz" .. "a" """)
+
+    val array: List[MoeObject] = result.asInstanceOf[MoeArrayObject].getNativeValue
+
+    assert(array.size === 0)
   }
 
 }


### PR DESCRIPTION
Ranges should support string ranges too. Just basic stuff. Doesn't handle mixed type ranges like `1 .. "5"`.

Still learning Scala, it is probably completely non-idiomatic, so feel free to improve it.
