### PR TITLE
more useable REPL with jline 1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,3 +9,14 @@ scalacOptions ++= Seq("-deprecation", "-unchecked")
 libraryDependencies += "org.scalatest" % "scalatest_2.10" % "1.9.1" % "test"
 
 libraryDependencies += "commons-cli" % "commons-cli" % "1.2" % "compile"
+
+libraryDependencies += "jline" % "jline" % "1.0"
+
+// execute "run" task in a forked process
+fork in run := true
+
+// forward standard input to forked "run" process
+connectInput in run := true
+
+// send output to the build's standard output and error
+outputStrategy := Some(StdoutOutput)

--- a/src/main/scala/org/moe/Moe.scala
+++ b/src/main/scala/org/moe/Moe.scala
@@ -121,12 +121,18 @@ object Moe {
    */
   object REPL {
     def enter (interpreter: Interpreter, runtime: MoeRuntime, dumpAST: Boolean = false): Unit = {
+      import jline.ConsoleReader
+
+      val cReader: ConsoleReader = new ConsoleReader
+      val prompt = "moe> "
+
       while (true) {
-        val line = readLine("> ")
-        if (line != null && line != "exit") {
+        val line = cReader readLine prompt
+        if (line != null && line.length > 0 && line != "exit") {
           evalLine(interpreter, runtime, line, dumpAST)
         }
         else {
+          if (line != "exit") println()
           return
         }
       }


### PR DESCRIPTION
REPL with editline support using jline 1.0. (see issue https://github.com/MoeOrganization/moe/issues/38)

First, I tried to use svatsan's code using jline2 (from the extra-y-stuff branch). It almost worked, except for one problem. Upon exiting from moe> prompt to sbt, the character echo wasn't being turned back on. I couldn't fix it, so I tried going back to jline 1.0, which didn't have this problem.

http://www.scala-sbt.org/release/docs/Detailed-Topics/Forking was helpful in updating sbt configuration.
