### PR TITLE
IfNode rewrite

### DIFF
--- a/src/main/scala/org/moe/ast/AST.scala
+++ b/src/main/scala/org/moe/ast/AST.scala
@@ -11,6 +11,14 @@ case class ScopeNode(body: StatementsNode) extends AST
 
 case class StatementsNode(nodes: List[AST]) extends AST
 
+case class IfStruct (
+  var condition: AST,
+  var body: AST, 
+  var else_node: IfStruct = null
+) extends AST
+
+case class IfNode(if_node: IfStruct) extends AST 
+
 // literals
 
 /**
@@ -80,26 +88,8 @@ case class SubroutineCallNode(function_name: String, args: List[AST]) extends AS
 
 // statements
 
-case class IfNode(if_condition: AST, if_body: AST) extends AST
-case class IfElseNode(if_condition: AST, if_body: AST, else_body: AST) extends AST
-case class IfElsifNode(
-  if_condition: AST,
-  if_body: AST,
-  elsif_condition: AST,
-  elsif_body: AST)
-  extends AST
-case class IfElsifElseNode(
-  if_condition: AST,
-  if_body: AST,
-  elsif_condition: AST,
-  elsif_body: AST,
-  else_body: AST)
-  extends AST
-
 case class UnlessNode(unless_condition: AST, unless_body: AST) extends AST
 case class UnlessElseNode(unless_condition: AST, unless_body: AST, else_body: AST) extends AST
-// TODO: UnlessElsif and UnlessElsifElse to match If above?
-// Or should the normalization be handled by the parser instead? -TRS
 
 case class TryNode(
   body: AST,

--- a/src/main/scala/org/moe/ast/Serializer.scala
+++ b/src/main/scala/org/moe/ast/Serializer.scala
@@ -244,48 +244,11 @@ object Serializer {
       )
     )
 
-    case IfNode(if_condition, if_body) => JSONObject(
+    case IfNode(if_node) => JSONObject(
       Map(
         "IfNode" -> JSONObject(
           Map(
-            "if_condition" -> toJSON(if_condition),
-            "if_body"      -> toJSON(if_body)
-          )
-        )
-      )
-    )
-    case IfElseNode(if_condition, if_body, else_body) => JSONObject(
-      Map(
-        "IfElseNode" -> JSONObject(
-          Map(
-            "if_condition" -> toJSON(if_condition),
-            "if_body"      -> toJSON(if_body),
-            "else_body"    -> toJSON(else_body)
-          )
-        )
-      )
-    )
-    case IfElsifNode(if_condition, if_body, elsif_condition, elsif_body) => JSONObject(
-      Map(
-        "IfElsifNode" -> JSONObject(
-          Map(
-            "if_condition"    -> toJSON(if_condition),
-            "if_body"         -> toJSON(if_body),
-            "elsif_condition" -> toJSON(elsif_condition),
-            "elsif_body"      -> toJSON(elsif_body)
-          )
-        )
-      )
-    )
-    case IfElsifElseNode(if_condition, if_body, elsif_condition, elsif_body, else_body) => JSONObject(
-      Map(
-        "IfElsifElseNode" -> JSONObject(
-          Map(
-            "if_condition"    -> toJSON(if_condition),
-            "if_body"         -> toJSON(if_body),
-            "elsif_condition" -> toJSON(elsif_condition),
-            "elsif_body"      -> toJSON(elsif_body),
-            "else_body"       -> toJSON(else_body)
+            "if_node" -> toJSON(if_node)
           )
         )
       )

--- a/src/main/scala/org/moe/interpreter/Interpreter.scala
+++ b/src/main/scala/org/moe/interpreter/Interpreter.scala
@@ -436,67 +436,34 @@ class Interpreter {
 
       // statements
 
-      case IfNode(if_condition, if_body) => {
-        eval(runtime, env,
-          IfElseNode(
-            if_condition,
-            if_body,
-            UndefLiteralNode()
-          )
-        )
-      }
-
-      case IfElseNode(if_condition, if_body, else_body) => {
-        if (eval(runtime, env, if_condition).isTrue) {
-          eval(runtime, env, if_body)
+      case IfNode(if_node) => {
+        if (eval(runtime, env, if_node.condition).isTrue) {
+          eval(runtime, env, if_node.body)
+        } else if (if_node.else_node != null) {
+          eval(runtime, env, IfNode(if_node.else_node))
         } else {
-          eval(runtime, env, else_body)
+          getUndef
         }
       }
-
-      case IfElsifNode(if_condition, if_body, elsif_condition, elsif_body) => {
-        eval(runtime, env,
-          IfElseNode(
-            if_condition,
-            if_body,
-            IfNode(
-              elsif_condition,
-              elsif_body
-            )
-          )
-        )
-      }
-
-      case IfElsifElseNode(if_condition, if_body, elsif_condition, elsif_body, else_body) => {
-        eval(runtime, env,
-          IfElseNode(
-            if_condition,
-            if_body,
-            IfElseNode(
-              elsif_condition,
-              elsif_body,
-              else_body
-            )
-          )
-        )
-      }
-
+          
       case UnlessNode(unless_condition, unless_body) => {
         eval(runtime, env,
           UnlessElseNode(
             unless_condition,
             unless_body,
-            UndefLiteralNode()
+            null
           )
         )
       }
       case UnlessElseNode(unless_condition, unless_body, else_body) => {
+        var else_node: IfStruct = null 
+        if (else_body != null) {
+          else_node = new IfStruct (BooleanLiteralNode(true), else_body)
+        } 
+        var if_node = new IfStruct (NotNode(unless_condition), unless_body, else_node)
+        
         eval(runtime, env,
-          IfElseNode(
-            NotNode(unless_condition),
-            unless_body,
-            else_body
-          )
+          IfNode(if_node)
         )
       }
 

--- a/src/main/scala/org/moe/interpreter/InterpreterUtils.scala
+++ b/src/main/scala/org/moe/interpreter/InterpreterUtils.scala
@@ -72,27 +72,8 @@ object InterpreterUtils {
         args.foreach(walkAST(_, callback))
       }
 
-      case IfNode(if_condition, if_body) => {
-        walkAST(if_condition, callback)
-        walkAST(if_body, callback)
-      }
-      case IfElseNode(if_condition, if_body, else_body) => {
-        walkAST(if_condition, callback)
-        walkAST(if_body, callback)
-        walkAST(else_body, callback)
-      }
-      case IfElsifNode(if_condition, if_body, elsif_condition, elsif_body) => {
-        walkAST(if_condition, callback)
-        walkAST(if_body, callback)
-        walkAST(elsif_condition, callback)
-        walkAST(elsif_body, callback)
-      }
-      case IfElsifElseNode(if_condition, if_body, elsif_condition, elsif_body, else_body) => {
-        walkAST(if_condition, callback)
-        walkAST(if_body, callback)
-        walkAST(elsif_condition, callback)
-        walkAST(elsif_body, callback)
-        walkAST(else_body, callback)
+      case IfNode(if_node) => {
+        walkAST(if_node, callback)
       }
 
       case UnlessNode(unless_condition, unless_body) => {

--- a/src/main/scala/org/moe/parser/Statements.scala
+++ b/src/main/scala/org/moe/parser/Statements.scala
@@ -36,7 +36,7 @@ trait Statements extends Expressions {
   def loop: Parser[AST] = ifLoop // | forLoop | foreachLoop | whileLoop
 
   def ifLoop: Parser[AST] =
-    (("if" ~ "(") ~> expression) ~ (")" ~> block) ^^ { case a ~ b => IfNode(a,b) }
+    (("if" ~ "(") ~> expression) ~ (")" ~> block) ^^ { case a ~ b => IfNode(new IfStruct(a,b)) }
 
   // def forLoop = "for" ~ "(" ~> expression <~ ";" ~> expression <~ ";" ~> expression <~ ")" ~ block
   // def whileLoop = "if" ~ "(" ~> expression <~ ")" ~ block

--- a/src/test/scala/org/moe/interpreter/IfNodeTestSuite.scala
+++ b/src/test/scala/org/moe/interpreter/IfNodeTestSuite.scala
@@ -11,8 +11,10 @@ class IfNodeTestSuite extends FunSuite with InterpreterTestUtils {
     val ast = wrapSimpleAST(
       List(
         IfNode(
-          BooleanLiteralNode(true),
-          IntLiteralNode(1)
+          new IfStruct(
+            BooleanLiteralNode(true),
+            IntLiteralNode(1)
+          )
         )
       )
     )
@@ -24,8 +26,10 @@ class IfNodeTestSuite extends FunSuite with InterpreterTestUtils {
     val ast = wrapSimpleAST(
       List(
         IfNode(
-          BooleanLiteralNode(false),
-          IntLiteralNode(1)
+          new IfStruct(
+            BooleanLiteralNode(false),
+            IntLiteralNode(1)
+          )
         )
       )
     )
@@ -33,13 +37,15 @@ class IfNodeTestSuite extends FunSuite with InterpreterTestUtils {
     assert(result === runtime.NativeObjects.getUndef)
   }
 
-  test("... basic test with IfElse") {
+  test("... basic test with If () Else") {
     val ast = wrapSimpleAST(
       List(
-        IfElseNode(
-          BooleanLiteralNode(true),
-          IntLiteralNode(2),
-          IntLiteralNode(3)
+        IfNode(
+          new IfStruct(
+            BooleanLiteralNode(true),
+            IntLiteralNode(2), 
+            new IfStruct(BooleanLiteralNode(true), IntLiteralNode(3))
+          )
         )
       )
     )
@@ -47,13 +53,15 @@ class IfNodeTestSuite extends FunSuite with InterpreterTestUtils {
     assert(result.unboxToInt.get === 2)
   }
 
-  test("... basic (false) test with IfElse") {
+  test("... basic (false) test with If () Else") {
     val ast = wrapSimpleAST(
       List(
-        IfElseNode(
-          BooleanLiteralNode(false),
-          IntLiteralNode(2),
-          IntLiteralNode(3)
+        IfNode(
+          new IfStruct(
+            BooleanLiteralNode(false),
+            IntLiteralNode(2), 
+            new IfStruct(BooleanLiteralNode(true), IntLiteralNode(3))
+          )
         )
       )
     )
@@ -64,11 +72,12 @@ class IfNodeTestSuite extends FunSuite with InterpreterTestUtils {
   test("... basic (true/true) test with IfElsif (true/true)") {
     val ast = wrapSimpleAST(
       List(
-        IfElsifNode(
-          BooleanLiteralNode(true),
-          IntLiteralNode(5),
-          BooleanLiteralNode(true),
-          IntLiteralNode(8)
+        IfNode(
+          new IfStruct(
+            BooleanLiteralNode(true),
+            IntLiteralNode(5), 
+            new IfStruct(BooleanLiteralNode(true), IntLiteralNode(8))
+          )
         )
       )
     )
@@ -79,11 +88,12 @@ class IfNodeTestSuite extends FunSuite with InterpreterTestUtils {
   test("... basic (false/true) test with IfElsif") {
     val ast = wrapSimpleAST(
       List(
-        IfElsifNode(
-          BooleanLiteralNode(false),
-          IntLiteralNode(5),
-          BooleanLiteralNode(true),
-          IntLiteralNode(8)
+        IfNode(
+          new IfStruct(
+            BooleanLiteralNode(false),
+            IntLiteralNode(5), 
+            new IfStruct(BooleanLiteralNode(true), IntLiteralNode(8))
+          )
         )
       )
     )
@@ -94,11 +104,12 @@ class IfNodeTestSuite extends FunSuite with InterpreterTestUtils {
   test("... basic (false/false) test with IfElseIf") {
     val ast = wrapSimpleAST(
       List(
-        IfElsifNode(
-          BooleanLiteralNode(false),
-          IntLiteralNode(13),
-          BooleanLiteralNode(false),
-          IntLiteralNode(21)
+        IfNode(
+          new IfStruct(
+            BooleanLiteralNode(false),
+            IntLiteralNode(5), 
+            new IfStruct(BooleanLiteralNode(false), IntLiteralNode(8))
+          )
         )
       )
     )
@@ -109,12 +120,14 @@ class IfNodeTestSuite extends FunSuite with InterpreterTestUtils {
   test("... basic (true/true) test with IfElsifElse") {
     val ast = wrapSimpleAST(
       List(
-        IfElsifElseNode(
-          BooleanLiteralNode(true),
-          IntLiteralNode(34),
-          BooleanLiteralNode(true),
-          IntLiteralNode(55),
-          IntLiteralNode(89)
+        IfNode(
+          new IfStruct(
+            BooleanLiteralNode(true),
+            IntLiteralNode(34), 
+            new IfStruct(BooleanLiteralNode(true), IntLiteralNode(55),
+              new IfStruct(BooleanLiteralNode(true), IntLiteralNode(89))
+            )
+          )
         )
       )
     )
@@ -125,12 +138,14 @@ class IfNodeTestSuite extends FunSuite with InterpreterTestUtils {
   test("... basic (false/true) test with IfElsifElse") {
     val ast = wrapSimpleAST(
       List(
-        IfElsifElseNode(
-          BooleanLiteralNode(false),
-          IntLiteralNode(34),
-          BooleanLiteralNode(true),
-          IntLiteralNode(55),
-          IntLiteralNode(89)
+        IfNode(
+          new IfStruct(
+            BooleanLiteralNode(false),
+            IntLiteralNode(34), 
+            new IfStruct(BooleanLiteralNode(true), IntLiteralNode(55),
+              new IfStruct(BooleanLiteralNode(true), IntLiteralNode(89))
+            )
+          )
         )
       )
     )
@@ -141,12 +156,14 @@ class IfNodeTestSuite extends FunSuite with InterpreterTestUtils {
   test("... basic (false/false) test with IfElsifElse") {
     val ast = wrapSimpleAST(
       List(
-        IfElsifElseNode(
-          BooleanLiteralNode(false),
-          IntLiteralNode(34),
-          BooleanLiteralNode(false),
-          IntLiteralNode(55),
-          IntLiteralNode(89)
+        IfNode(
+          new IfStruct(
+            BooleanLiteralNode(false),
+            IntLiteralNode(34), 
+            new IfStruct(BooleanLiteralNode(false), IntLiteralNode(55),
+              new IfStruct(BooleanLiteralNode(true), IntLiteralNode(89))
+            )
+          )
         )
       )
     )


### PR DESCRIPTION
This is probably messed up because I don't understand Scala.  By the time I developed an idea of what I was doing I thought some things might not be needed anymore, and may have gotten nasty in a few places (using null to avoid type mismatches between UndefLiteral and IfStruct)

In general, the theory I was trying to get at was that IfNode() should be somewhat recursive.  The Parser should build up the IfNode structure and send it.  If this were C I would say that else_node is a pointer to the next IfNode if it's defined (in this case, since it's an object it might be getting instantiated as the IfStruct is built and thus consume memory when it will never be executed.  We don't want that, but I don't know how to tell Scala about pointers)

Comments welcome.  This can certainly be trashed if it does a bad thing. :)
