### PR TITLE
format embedded escaped characters (newlines, tabs etc) in double-quited string literals

### DIFF
--- a/spec/syntax-examples/001-literals/004-string-literals/004.ast
+++ b/spec/syntax-examples/001-literals/004-string-literals/004.ast
@@ -1,1 +1,1 @@
-{"StatementsNode" : [{"StringLiteralNode" : "foo\\\"bar\\\""}]}
+{"StatementsNode" : [{"StringLiteralNode" : "foo\"bar\""}]}

--- a/src/main/scala/org/moe/parser/Literals.scala
+++ b/src/main/scala/org/moe/parser/Literals.scala
@@ -47,7 +47,7 @@ trait Literals extends Base {
   // - SL
 
   def doubleQuoteStringContents: Parser[StringLiteralNode] =
-    """([^"\p{Cntrl}\\]|\\[\\'"bfnrt]|\\x\{[a-fA-F0-9]{4}\})*""".r ^^ StringLiteralNode
+    """([^"\p{Cntrl}\\]|\\[\\'"bfnrt]|\\x\{[a-fA-F0-9]{4}\})*""".r ^^ { s => StringLiteralNode(formatStr(s)) }
   def singleQuoteStringContents: Parser[StringLiteralNode] =
     """([^'\p{Cntrl}\\]|\\[\\'"bfnrt]|\\x\{[a-fA-F0-9]{4}\})*""".r ^^ StringLiteralNode
 

--- a/src/main/scala/org/moe/parser/ParserUtils.scala
+++ b/src/main/scala/org/moe/parser/ParserUtils.scala
@@ -9,4 +9,17 @@ object ParserUtils {
   def formatHex   (s: String): Int    = Integer.parseInt( normPerlInt(s).substring(2).toUpperCase, 16 )
   def formatBin   (s: String): Int    = Integer.parseInt( normPerlInt(s).substring(2).toUpperCase, 2  )
 
+  // handle escaped characters in double-quoted strings
+  def formatStr   (s: String): String = {
+    val escaped = Map(
+      "\\b" -> "\b",
+      "\\f" -> "\f",
+      "\\n" -> "\n",
+      "\\r" -> "\r",
+      "\\t" -> "\t"
+    )
+    val escapes = """\\([bfnrt'"])""".r
+    escapes.replaceAllIn(s, m => escaped.getOrElse(m.group(0), m.group(0).tail))
+  }
+
 }

--- a/src/test/scala/org/moe/parser/StringLiteralTestSuite.scala
+++ b/src/test/scala/org/moe/parser/StringLiteralTestSuite.scala
@@ -19,12 +19,12 @@ class StringLiteralTestSuite extends FunSuite with BeforeAndAfter with ParserTes
 
   test("... basic test with a double-quoted string with control characters") {
     val result = interpretCode(""" "foo\tbar\n" """)
-    assert(result.unboxToString.get === "foo\\tbar\\n")
+    assert(result.unboxToString.get === "foo\tbar\n")
   }
 
   test("... basic test with a double-quoted string with escaped quotes") {
     val result = interpretCode(""" "foo\"bar\"" """)
-    assert(result.unboxToString.get === "foo\\\"bar\\\"")
+    assert(result.unboxToString.get === "foo\"bar\"")
   }
 
   //


### PR DESCRIPTION
This change translates escaped characters in double-quoted string literals (like \n, \t etc) to their internal representation.
