### PR TITLE
pretty-printing of AST dumps and a bit of configurability for REPL

### DIFF
--- a/src/main/scala/org/moe/ast/Serializer.scala
+++ b/src/main/scala/org/moe/ast/Serializer.scala
@@ -50,7 +50,7 @@ object Serializer {
           )
         )
       )
-    )  
+    )
 
     case PostfixUnaryOpNode(lhs, operator) => JSONObject(
       Map(
@@ -61,7 +61,7 @@ object Serializer {
           )
         )
       )
-    )  
+    )
 
     case BinaryOpNode(lhs, operator, rhs) => JSONObject(
       Map(
@@ -339,5 +339,27 @@ object Serializer {
 
     case _ => "stub"
   }
-}
 
+  // thanks to https://gist.github.com/umitanuki/944839
+  def pprint(j: Option[Any], l: Int = 0):String = {
+    val indent = (for(i <- List.range(0, l)) yield "  ").mkString
+    j match{
+      case Some(o: JSONObject) => {
+        List("{",
+             o.obj.keys.map(key => indent + "  " + "\"" + key + "\" : " + pprint(o.obj.get(key), l + 1)).mkString(",\n"),
+             indent + "}").mkString("\n")
+      }
+      case Some(a: JSONArray) => {
+        List("[",
+             a.list.map(v => indent + "  " + pprint(Some(v), l + 1)).mkString(",\n"),
+             indent + "]").mkString("\n")
+      }
+      case Some(s: String) => "\"" + s + "\""
+      case Some(n: Number) => n.toString
+      case None => "null"
+      case _ => "undefined"
+    }
+  }
+
+  def toJSONPretty(ast: AST): String = pprint(Some(toJSON(ast)))
+}


### PR DESCRIPTION
```
moe> 1 + 2
{"CompilationUnitNode" : {"ScopeNode" : {"StatementsNode" : [{"BinaryOpNode" : {"lhs" : {"IntLiteralNode" : 1}, "operator" : "+", "rhs" : {"IntLiteralNode" : 2}}}]}}}
3
```

Turn on pretty-printing (use **on**, or **yes**, or **1** for option values)

```
moe> :set prettyPrintAST 1

moe> 1 + 2
{
  "CompilationUnitNode" : {
    "ScopeNode" : {
      "StatementsNode" : [
        {
          "BinaryOpNode" : {
            "lhs" : {
              "IntLiteralNode" : 1
            },
            "operator" : "+",
            "rhs" : {
              "IntLiteralNode" : 2
            }
          }
        }
      ]
    }
  }
}
3
```

Other options handled for now: **printOutput** and **dumpAST**
