### PR TITLE
More operators for ints/strings

### DIFF
--- a/src/main/scala/org/moe/ast/AST.scala
+++ b/src/main/scala/org/moe/ast/AST.scala
@@ -52,6 +52,7 @@ case class PostfixUnaryOpNode(rhs: AST, operator: String) extends AST
 // binary operators
 
 case class BinaryOpNode(lhs: AST, operator: String, rhs: AST) extends AST
+case class ShortCircuitBinaryOpNode(lhs: AST, operator: String, rhs: AST) extends AST
 
 // value lookup, assignment and declaration
 

--- a/src/main/scala/org/moe/ast/Serializer.scala
+++ b/src/main/scala/org/moe/ast/Serializer.scala
@@ -75,6 +75,18 @@ object Serializer {
       )
     )
 
+    case ShortCircuitBinaryOpNode(lhs, operator, rhs) => JSONObject(
+      Map(
+        "ShortCircuitBinaryOpNode" -> JSONObject(
+          Map(
+            "lhs"      -> toJSON(lhs),
+            "operator" -> operator,
+            "rhs"      -> toJSON(rhs)
+          )
+        )
+      )
+    )
+
     case ClassAccessNode(name) => JSONObject(Map("ClassAccessNode" -> name))
 
     case ClassDeclarationNode(name, superclass, body) => JSONObject(

--- a/src/main/scala/org/moe/interpreter/Interpreter.scala
+++ b/src/main/scala/org/moe/interpreter/Interpreter.scala
@@ -174,6 +174,22 @@ class Interpreter {
         )
       }
 
+      // short circuit binary operators
+      // rhs is not evaluated, unless it is necessary
+
+      case ShortCircuitBinaryOpNode(lhs: AST, operator: String, rhs: AST) => {
+        val receiver = eval(runtime, env, lhs)
+        val arg      = new MoeLazyEval(this, runtime, env, rhs)
+        receiver.callMethod(
+          receiver.getAssociatedClass.getOrElse(
+            throw new MoeErrors.ClassNotFound(receiver.toString)
+          ).getMethod("infix:<" + operator + ">").getOrElse(
+            throw new MoeErrors.MethodNotFound("method infix:<" + operator + "> missing in class " + receiver.getClassName)
+          ), 
+          List(arg)
+        )
+      }
+
       // value lookup, assignment and declaration
 
       case ClassAccessNode(name) => {

--- a/src/main/scala/org/moe/parser/Expressions.scala
+++ b/src/main/scala/org/moe/parser/Expressions.scala
@@ -30,7 +30,7 @@ trait Expressions extends Literals with JavaTokenParsers with PackratParsers {
   // TODO: right       ?:
 
 
-  // left        || //
+  // left        ||           TODO: //
   lazy val logicalOrOp: PackratParser[AST] = logicalOrOp ~ """\|\||//""".r ~ logicalAndOp ^^ {
     case left ~ op ~ right => ShortCircuitBinaryOpNode(left, op, right)
   } | logicalAndOp
@@ -46,13 +46,17 @@ trait Expressions extends Literals with JavaTokenParsers with PackratParsers {
   } | bitAndOp
 
   // left        &
-  lazy val bitAndOp: PackratParser[AST] = bitAndOp ~ "&" ~ relOp ^^ {
+  lazy val bitAndOp: PackratParser[AST] = bitAndOp ~ "&" ~ eqOp ^^ {
+    case left ~ op ~ right => BinaryOpNode(left, op, right)
+  } | eqOp
+
+  // nonassoc    == != eq ne cmp ~~
+  lazy val eqOp: PackratParser[AST] = eqOp ~ "[!=]=|<=>|eq|ne|cmp".r ~ relOp ^^ {
     case left ~ op ~ right => BinaryOpNode(left, op, right)
   } | relOp
 
-  // nonassoc    == != <=> eq ne cmp ~~
   // nonassoc    < > <= >= lt gt le ge
-  lazy val relOp: PackratParser[AST] = relOp ~ "[<>]=?|[!=]=".r ~ addOp ^^ {
+  lazy val relOp: PackratParser[AST] = relOp ~ "[<>]=?|lt|gt|le|ge".r ~ addOp ^^ {
     case left ~ op ~ right => BinaryOpNode(left, op, right)
   } | addOp
 

--- a/src/main/scala/org/moe/runtime/MoeLazyEval.scala
+++ b/src/main/scala/org/moe/runtime/MoeLazyEval.scala
@@ -1,0 +1,22 @@
+package org.moe.runtime
+
+import org.moe.interpreter._
+import org.moe.runtime._
+import org.moe.ast._
+
+/**
+ * MoeLazyEval: Class for wrapping an AST node whose evaluation is deferred.
+ *
+ */
+
+class MoeLazyEval (
+  interpreter: Interpreter,
+  runtime: MoeRuntime,
+  env: MoeEnvironment,
+  node: AST
+) extends MoeObject {
+  def eval = {
+    println("lazy eval - " + Serializer.toJSONPretty(node))
+    interpreter.eval(runtime, env, node)
+  }
+}

--- a/src/main/scala/org/moe/runtime/builtins/AnyClass.scala
+++ b/src/main/scala/org/moe/runtime/builtins/AnyClass.scala
@@ -33,7 +33,13 @@ object AnyClass {
         env, 
         { (e) =>
             val inv = e.getCurrentInvocant.get
-            if (inv.isTrue) e.get("$other").get else inv
+            if (inv.isFalse)
+              inv
+            else
+              e.get("$other").get match {
+                case deferred: MoeLazyEval => deferred.eval
+                case other:    MoeObject   => other
+              }
         }
       )
     )
@@ -45,7 +51,13 @@ object AnyClass {
         env, 
         { (e) =>
             val inv = e.getCurrentInvocant.get
-            if (inv.isTrue) inv else e.get("$other").get
+            if (inv.isTrue)
+              inv
+            else
+              e.get("$other").get match {
+                case deferred: MoeLazyEval => deferred.eval
+                case other:    MoeObject   => other
+              }
         }
       )
     )

--- a/src/main/scala/org/moe/runtime/builtins/BoolClass.scala
+++ b/src/main/scala/org/moe/runtime/builtins/BoolClass.scala
@@ -1,6 +1,7 @@
 package org.moe.runtime.builtins
 
 import org.moe.runtime._
+import org.moe.runtime.nativeobjects._
 
 /**
   * setup class Bool
@@ -13,7 +14,20 @@ object BoolClass {
       throw new MoeErrors.MoeStartupError("Could not find class Bool")
     )
 
+    def self(e: MoeEnvironment): MoeBoolObject = e.getCurrentInvocant.get.asInstanceOf[MoeBoolObject]
+
     // MRO: Bool, Scalar, Any, Object
+
+    import r.NativeObjects._
+
+    boolClass.addMethod(
+      new MoeMethod(
+        "prefix:<+>",
+        new MoeSignature(),
+        env,
+        (e) => getInt(self(e).unboxToInt.getOrElse(0))
+      )
+    )
 
     /**
      * List of Methods to support:

--- a/src/main/scala/org/moe/runtime/builtins/IntClass.scala
+++ b/src/main/scala/org/moe/runtime/builtins/IntClass.scala
@@ -180,6 +180,8 @@ object IntClass {
       )
     )
 
+    // equality operators
+
     intClass.addMethod(
       new MoeMethod(
         "infix:<==>",
@@ -195,6 +197,15 @@ object IntClass {
         new MoeSignature(List(new MoeParameter("$other"))),
         env,
         (e) => e.getCurrentInvocant.get.asInstanceOf[MoeIntObject].not_equal_to(r, e.get("$other").get)
+      )
+    )
+
+    intClass.addMethod(
+      new MoeMethod(
+        "infix:<<=>>",
+        new MoeSignature(List(new MoeParameter("$other"))),
+        env,
+        (e) => e.getCurrentInvocant.get.asInstanceOf[MoeIntObject].compare_to(r, e.get("$other").get)
       )
     )
 

--- a/src/main/scala/org/moe/runtime/builtins/StrClass.scala
+++ b/src/main/scala/org/moe/runtime/builtins/StrClass.scala
@@ -47,7 +47,72 @@ object StrClass {
       )
     )
 
-    // operators
+    // relational operators
+
+    strClass.addMethod(
+      new MoeMethod(
+        "infix:<lt>",
+        new MoeSignature(List(new MoeParameter("$other"))),
+        env,
+        (e) => e.getCurrentInvocant.get.asInstanceOf[MoeStrObject].less_than(r, e.get("$other").get)
+      )
+    )
+
+    strClass.addMethod(
+      new MoeMethod(
+        "infix:<gt>",
+        new MoeSignature(List(new MoeParameter("$other"))),
+        env,
+        (e) => e.getCurrentInvocant.get.asInstanceOf[MoeStrObject].greater_than(r, e.get("$other").get)
+      )
+    )
+
+    strClass.addMethod(
+      new MoeMethod(
+        "infix:<le>",
+        new MoeSignature(List(new MoeParameter("$other"))),
+        env,
+        (e) => e.getCurrentInvocant.get.asInstanceOf[MoeStrObject].less_than_or_equal_to(r, e.get("$other").get)
+      )
+    )
+
+    strClass.addMethod(
+      new MoeMethod(
+        "infix:<ge>",
+        new MoeSignature(List(new MoeParameter("$other"))),
+        env,
+        (e) => e.getCurrentInvocant.get.asInstanceOf[MoeStrObject].greater_than_or_equal_to(r, e.get("$other").get)
+      )
+    )
+
+    // equality operators
+
+    strClass.addMethod(
+      new MoeMethod(
+        "infix:<eq>",
+        new MoeSignature(List(new MoeParameter("$other"))),
+        env,
+        (e) => e.getCurrentInvocant.get.asInstanceOf[MoeStrObject].equal_to(r, e.get("$other").get)
+      )
+    )
+
+    strClass.addMethod(
+      new MoeMethod(
+        "infix:<ne>",
+        new MoeSignature(List(new MoeParameter("$other"))),
+        env,
+        (e) => e.getCurrentInvocant.get.asInstanceOf[MoeStrObject].not_equal_to(r, e.get("$other").get)
+      )
+    )
+
+    strClass.addMethod(
+      new MoeMethod(
+        "infix:<cmp>",
+        new MoeSignature(List(new MoeParameter("$other"))),
+        env,
+        (e) => e.getCurrentInvocant.get.asInstanceOf[MoeStrObject].compare_to(r, e.get("$other").get)
+      )
+    )
 
     // methods
 

--- a/src/main/scala/org/moe/runtime/nativeobjects/MoeBoolObject.scala
+++ b/src/main/scala/org/moe/runtime/nativeobjects/MoeBoolObject.scala
@@ -1,6 +1,7 @@
 package org.moe.runtime.nativeobjects
 
 import org.moe.runtime._
+import org.moe.runtime.nativeobjects._
 
 import scala.util.{Try, Success, Failure}
 
@@ -8,8 +9,14 @@ class MoeBoolObject(
     v: Boolean, klass : Option[MoeClass] = None
   ) extends MoeNativeObject[Boolean](v, klass) {
 
-  // MoeObject overrides
+  // runtime methods
+
+  def toInt: Int = if (getNativeValue) 1 else 0
 
   override def isFalse: Boolean = getNativeValue == false
   override def toString: String = if (getNativeValue) "true" else "false"
+
+  // unboxing
+
+  override def unboxToInt: Try[Int] = Try(toInt)
 }

--- a/src/main/scala/org/moe/runtime/nativeobjects/MoeIntObject.scala
+++ b/src/main/scala/org/moe/runtime/nativeobjects/MoeIntObject.scala
@@ -64,6 +64,12 @@ class MoeIntObject(
     case _               => throw new MoeErrors.UnexpectedType(other.toString)
   }
 
+  def compare_to (r: MoeRuntime, other: MoeObject): MoeIntObject = other match {
+    case i: MoeIntObject => r.NativeObjects.getInt(getNativeValue    compareTo i.unboxToInt.get)
+    case f: MoeNumObject => r.NativeObjects.getInt(unboxToDouble.get compareTo f.unboxToDouble.get)
+    case _               => throw new MoeErrors.UnexpectedType(other.toString)
+  }
+
   // comparison
 
   def less_than (r: MoeRuntime, other: MoeObject): MoeBoolObject = other match {

--- a/src/main/scala/org/moe/runtime/nativeobjects/MoeStrObject.scala
+++ b/src/main/scala/org/moe/runtime/nativeobjects/MoeStrObject.scala
@@ -64,6 +64,36 @@ class MoeStrObject(
     r.NativeObjects.getStr(List.fill(n)(str).mkString)
   }
 
+  // equality
+
+  def equal_to (r: MoeRuntime, other: MoeObject): MoeBoolObject =
+    r.NativeObjects.getBool(getNativeValue == other.unboxToString.get)
+
+  def not_equal_to (r: MoeRuntime, other: MoeObject): MoeBoolObject =
+    r.NativeObjects.getBool(getNativeValue != other.unboxToString.get)
+
+  def compare_to (r: MoeRuntime, other: MoeObject): MoeIntObject =
+    r.NativeObjects.getInt(
+      getNativeValue compareTo other.unboxToString.get match {
+        case 0 => 0
+        case r => if (r < 0) -1 else 1
+      }
+    )
+
+  // comparison
+
+  def less_than (r: MoeRuntime, other: MoeObject): MoeBoolObject =
+    r.NativeObjects.getBool(getNativeValue < other.unboxToString.get)
+
+  def greater_than (r: MoeRuntime, other: MoeObject): MoeBoolObject =
+    r.NativeObjects.getBool(getNativeValue > other.unboxToString.get)
+
+  def less_than_or_equal_to (r: MoeRuntime, other: MoeObject): MoeBoolObject =
+    r.NativeObjects.getBool(getNativeValue <= other.unboxToString.get)
+
+  def greater_than_or_equal_to (r: MoeRuntime, other: MoeObject): MoeBoolObject =
+    r.NativeObjects.getBool(getNativeValue >= other.unboxToString.get)
+
   // MoeObject overrides
 
   override def isFalse: Boolean = getNativeValue match {

--- a/src/test/scala/org/moe/parser/SimpleExpressionBoolTestSuite.scala
+++ b/src/test/scala/org/moe/parser/SimpleExpressionBoolTestSuite.scala
@@ -1,0 +1,112 @@
+package org.moe.parser
+
+import org.scalatest.FunSuite
+import org.scalatest.BeforeAndAfter
+import org.scalatest.matchers.ShouldMatchers
+
+import org.moe.runtime._
+import org.moe.interpreter._
+import org.moe.ast._
+import org.moe.parser._
+
+class SimpleExpressionBoolTestSuite extends FunSuite with BeforeAndAfter with ParserTestUtils with ShouldMatchers {
+
+  test("... literal bool stringification ... [3 > 1 ==> true]") {
+    val result = interpretCode("3 > 1")
+    result.unboxToString.get should equal ("true")
+  }
+
+  test("... literal bool stringification ... [3 == 1 ==> false]") {
+    val result = interpretCode("3 == 1")
+    result.unboxToString.get should equal ("false")
+  }
+
+  test("... literal bool numification ... [3 > 1 ==> 1]") {
+    val result = interpretCode("3 > 1")
+    result.unboxToInt.get should equal (1)
+  }
+
+  test("... literal bool numification ... [3 == 1 ==> 0]") {
+    val result = interpretCode("3 == 1")
+    result.unboxToInt.get should equal (0)
+  }
+
+  // not
+
+  test("... literal bool -- not ... [!(3 == 1) ==> true]") {
+    val result = interpretCode("!(3 == 1)")
+    result.unboxToBoolean.get should equal (true)
+  }
+
+  test("... literal bool -- not ... [!(3 != 1) ==> false]") {
+    val result = interpretCode("!(3 != 1)")
+    result.unboxToBoolean.get should equal (false)
+  }
+
+  // or
+
+  test("... literal bool -- or [false || true ==> true] ... [3 == 1 || 3 == 3]") {
+    val result = interpretCode("3 == 1 || 3 == 3")
+    result.unboxToBoolean.get should equal (true)
+  }
+
+  test("... literal bool -- or [true || false ==> true] ... [3 != 1 || 2 == 1]") {
+    val result = interpretCode("3 != 1 || 2 == 1 ")
+    result.unboxToBoolean.get should equal (true)
+  }
+
+  test("... literal bool -- or [true || true ==> true] ... [3 != 1 || 2 != 1]") {
+    val result = interpretCode("3 != 1 || 2 != 1 ")
+    result.unboxToBoolean.get should equal (true)
+  }
+
+  test("... literal bool -- or [false || false ==> false] ... [3 == 1 || 2 == 1]") {
+    val result = interpretCode("3 == 1 || 2 == 1 ")
+    result.unboxToBoolean.get should equal (false)
+  }
+
+  // and
+
+  test("... literal bool -- and [false && true ==> false] ... [3 == 1 && 3 == 3]") {
+    val result = interpretCode("3 == 1 && 3 == 3")
+    result.unboxToBoolean.get should equal (false)
+  }
+
+  test("... literal bool -- and [true && false ==> false] ... [3 != 1 && 2 == 1") {
+    val result = interpretCode("3 != 1 && 2 == 1 ")
+    result.unboxToBoolean.get should equal (false)
+  }
+
+  test("... literal bool -- and [true && true ==> true] ... [3 != 1 && 2 != 1]") {
+    val result = interpretCode("3 != 1 && 2 != 1 ")
+    result.unboxToBoolean.get should equal (true)
+  }
+
+  test("... literal bool -- and [false && false ==> false] ... [3 == 1 && 2 == 1]") {
+    val result = interpretCode("3 == 1 && 2 == 1 ")
+    result.unboxToBoolean.get should equal (false)
+  }
+
+  // logical or/and
+
+  test("... logical or ... [10 || 42]") {
+    val result = interpretCode("10 || 42")
+    result.unboxToInt.get should equal (10)
+  }
+
+  test("... logical or ... [0 || 42]") {
+    val result = interpretCode("0 || 42")
+    result.unboxToInt.get should equal (42)
+  }
+
+  test("... logical and ... [10 && 42]") {
+    val result = interpretCode("10 && 42")
+    result.unboxToInt.get should equal (42)
+  }
+
+  test("... logical or ... [42 && 0]") {
+    val result = interpretCode("42 && 0")
+    result.unboxToInt.get should equal (0)
+  }
+
+}

--- a/src/test/scala/org/moe/parser/SimpleExpressionStrTestSuite.scala
+++ b/src/test/scala/org/moe/parser/SimpleExpressionStrTestSuite.scala
@@ -41,4 +41,103 @@ class SimpleExpressionStrTestSuite extends FunSuite with BeforeAndAfter with Par
     result.unboxToString.get should equal ("MoeMoeMoeMoeMoe")
   }
 
+  // equality operators
+
+  test("""... literal string equality operation ... ["Moe" eq "Moe"]""") {
+    val result = interpretCode(""""Moe" eq "Moe"""")
+    result.unboxToBoolean.get should equal (true)
+  }
+
+  test("""... literal string equality operation ... ["Moe" eq "moe"]""") {
+    val result = interpretCode(""""Moe" eq "moe"""")
+    result.unboxToBoolean.get should equal (false)
+  }
+
+  test("""... literal string equality operation ... ["Moe" ne "Moe"]""") {
+    val result = interpretCode(""""Moe" ne "Moe"""")
+    result.unboxToBoolean.get should equal (false)
+  }
+
+  test("""... literal string equality operation ... ["Moe" ne "moe"]""") {
+    val result = interpretCode(""""Moe" ne "moe"""")
+    result.unboxToBoolean.get should equal (true)
+  }
+
+  test("""... literal string equality operation ... ["Moe" cmp "moe"]""") {
+    val result = interpretCode(""""Moe" cmp "moe"""")
+    result.unboxToInt.get should equal (-1)
+  }
+
+  test("""... literal string equality operation ... ["Moe" cmp "Moe"]""") {
+    val result = interpretCode(""""Moe" cmp "Moe"""")
+    result.unboxToInt.get should equal (0)
+  }
+
+  test("""... literal string equality operation ... ["moe" cmp "Moe"]""") {
+    val result = interpretCode(""""moe" cmp "Moe"""")
+    result.unboxToInt.get should equal (1)
+  }
+
+  // relational operators
+
+  test("""... literal string relational operation lt ... ["Moe" lt "moe"]""") {
+    val result = interpretCode(""""Moe" lt "moe"""")
+    result.unboxToBoolean.get should equal (true)
+  }
+
+  test("""... literal string relational operation lt ... ["moe" lt "Moe"]""") {
+    val result = interpretCode(""""moe" lt "Moe"""")
+    result.unboxToBoolean.get should equal (false)
+  }
+
+  test("""... literal string relational operation lt ... ["Moe" lt "Moe"]""") {
+    val result = interpretCode(""""Moe" lt "Moe"""")
+    result.unboxToBoolean.get should equal (false)
+  }
+
+  test("""... literal string relational operation gt ... ["Moe" gt "moe"]""") {
+    val result = interpretCode(""""Moe" gt "moe"""")
+    result.unboxToBoolean.get should equal (false)
+  }
+
+  test("""... literal string relational operation gt ... ["moe" gt "Moe"]""") {
+    val result = interpretCode(""""moe" gt "Moe"""")
+    result.unboxToBoolean.get should equal (true)
+  }
+
+  test("""... literal string relational operation gt ... ["Moe" gt "Moe"]""") {
+    val result = interpretCode(""""Moe" gt "Moe"""")
+    result.unboxToBoolean.get should equal (false)
+  }
+
+  test("""... literal string relational operation le ... ["Moe" le "Moe"]""") {
+    val result = interpretCode(""""Moe" le "Moe"""")
+    result.unboxToBoolean.get should equal (true)
+  }
+
+  test("""... literal string relational operation le ... ["Moe" le "moe"]""") {
+    val result = interpretCode(""""Moe" le "moe"""")
+    result.unboxToBoolean.get should equal (true)
+  }
+
+  test("""... literal string relational operation le ... ["moe" le "Moe"]""") {
+    val result = interpretCode(""""moe" le "Moe"""")
+    result.unboxToBoolean.get should equal (false)
+  }
+
+  test("""... literal string relational operation ge ... ["Moe" ge "Moe"]""") {
+    val result = interpretCode(""""Moe" ge "Moe"""")
+    result.unboxToBoolean.get should equal (true)
+  }
+
+  test("""... literal string relational operation ge ... ["Moe" ge "moe"]""") {
+    val result = interpretCode(""""Moe" ge "moe"""")
+    result.unboxToBoolean.get should equal (false)
+  }
+
+  test("""... literal string relational operation ge ... ["moe" ge "Moe"]""") {
+    val result = interpretCode(""""moe" ge "Moe"""")
+    result.unboxToBoolean.get should equal (true)
+  }
+
 }

--- a/src/test/scala/org/moe/parser/SimpleExpressionTestSuite.scala
+++ b/src/test/scala/org/moe/parser/SimpleExpressionTestSuite.scala
@@ -285,6 +285,33 @@ class SimpleExpressionTestSuite extends FunSuite with BeforeAndAfter with Parser
     result.unboxToInt.get should not equal (4096)
   }
 
+  // equality operators
+
+  test("... literal int equality operation ... [2 == 2]") {
+    val result = interpretCode("2 == 2")
+    result.unboxToBoolean.get should equal (true)
+  }
+
+  test("... literal int equality operation ... [2 != 2]") {
+    val result = interpretCode("2 != 2")
+    result.unboxToBoolean.get should equal (false)
+  }
+
+  test("... literal int equality operation ... [2 <=> 3]") {
+    val result = interpretCode("2 <=> 3")
+    result.unboxToInt.get should equal (-1)
+  }
+
+  test("... literal int equality operation ... [2 <=> 2]") {
+    val result = interpretCode("2 <=> 2")
+    result.unboxToInt.get should equal (0)
+  }
+
+  test("... literal int equality operation ... [3 <=> 2]") {
+    val result = interpretCode("3 <=> 2")
+    result.unboxToInt.get should equal (1)
+  }
+
   // relational operators
 
   test("... literal int relational operation #1 ... [1 < 2]") {
@@ -344,16 +371,6 @@ class SimpleExpressionTestSuite extends FunSuite with BeforeAndAfter with Parser
 
   test("... literal int relational operation #12 ... [1 >= 2.5]") {
     val result = interpretCode("1 >= 2.5")
-    result.unboxToBoolean.get should equal (false)
-  }
-
-  test("... literal int relational operation #13 ... [2 == 2]") {
-    val result = interpretCode("2 == 2")
-    result.unboxToBoolean.get should equal (true)
-  }
-
-  test("... literal int relational operation #14 ... [2 != 2]") {
-    val result = interpretCode("2 != 2")
     result.unboxToBoolean.get should equal (false)
   }
 


### PR DESCRIPTION
- short-circuiting C-style logical-or ("||") and logical-and ("&&") operators --
  I needed to create a new class MoeLazyEval to implement these. Please review. Feel free to improve the name and implementation.
- equality and relational operators for strings
- compare operator for ints and strings
