### PR TITLE
Few command line options

### DIFF
--- a/src/main/scala/org/moe/Moe.scala
+++ b/src/main/scala/org/moe/Moe.scala
@@ -99,11 +99,11 @@ object Moe {
           """
           my $__RUNNING_LINE_COUNT__ = 0;
           for $ARGV (@ARGV) {
-              my $argv_io = IO.new($ARGV);
+              my $__ARGV_IO__ = IO.new($ARGV);
               my $__LINE__ = 0;
-              while (!($argv_io.eof)) {
-                  my $_ = $argv_io.readline;
-                  if (!($argv_io.eof)) {
+              while (!($__ARGV_IO__.eof)) {
+                  my $_ = $__ARGV_IO__.readline;
+                  if (!($__ARGV_IO__.eof)) {
                       $__LINE__ = $__RUNNING_LINE_COUNT__ + $argv_io.input_line_number;
                       ## BEGIN INPUT CODE ##
           """ +

--- a/src/main/scala/org/moe/Moe.scala
+++ b/src/main/scala/org/moe/Moe.scala
@@ -24,6 +24,13 @@ object Moe {
 
     options.addOption("n", false, """assume "while (<>) { ... }" loop around program""")
     options.addOption("p", false, """assume loop like -n but print line also""")
+    options.addOption("a", false, """autosplit mode with -n or -p (splits $_ into @F)""")
+    // options.addOption("F", true,  """split() pattern for -a switch""")
+
+    val f = new Option("F", "split() pattern for -a switch")
+    f.setArgs(1)
+    f.setArgName("pattern")
+    options.addOption(f)
 
     val e = new Option("e", "code to evaluate")
     e.setArgs(1)
@@ -95,30 +102,35 @@ object Moe {
 
     def wrapCode(code: String) = {
       if (cmd.hasOption("n") || cmd.hasOption("p")) {
+
+        // TODO: should support regex pattern for -F option
+        val autosplitCode =
+          if (cmd.hasOption("a")) {
+            val split_pattern = if (cmd.hasOption("F")) cmd.getOptionValue("F") else " "
+            s"""my @F = $$_.split("$split_pattern");\n"""
+          }
+          else ""
+
+        val printOutputCode = if (cmd.hasOption("p")) "; say $_;" else ""
+
         val wrapped = 
-          """
-          my $__RUNNING_LINE_COUNT__ = 0;
-          for $ARGV (@ARGV) {
-              my $__ARGV_IO__ = IO.new($ARGV);
-              my $__LINE__ = 0;
-              while (!($__ARGV_IO__.eof)) {
-                  my $_ = $__ARGV_IO__.readline;
-                  if (!($__ARGV_IO__.eof)) {
-                      $__LINE__ = $__RUNNING_LINE_COUNT__ + $argv_io.input_line_number;
+          s"""
+          my $$__RUNNING_LINE_COUNT__ = 0;
+          for $$ARGV (@ARGV) {
+              my $$__ARGV_IO__ = IO.new($$ARGV);
+              my $$__LINE__ = 0;
+              while (!($$__ARGV_IO__.eof)) {
+                  my $$_ = $$__ARGV_IO__.readline;
+                  if (!($$__ARGV_IO__.eof)) {
+                      $$__LINE__ = $$__RUNNING_LINE_COUNT__ + $$__ARGV_IO__.input_line_number;
+                      $autosplitCode
                       ## BEGIN INPUT CODE ##
-          """ +
-          "            " + code.replaceAll("""\$\.""", """\$__LINE__""") +
-          """
-                      ## END INPUT CODE ##""" +
-          (if (cmd.hasOption("p"))
-             """
-                      ;
-                      say $_;"""
-           else "") +
-          """
+                      ${code.replaceAll("\\$\\.", "\\$__LINE__")}
+                      ## END INPUT CODE ##
+                      $printOutputCode
                   }
               }
-              $__RUNNING_LINE_COUNT__ = $__RUNNING_LINE_COUNT__ + $__LINE__;
+              $$__RUNNING_LINE_COUNT__ = $$__RUNNING_LINE_COUNT__ + $$__LINE__;
           }
           """
         if (runtime.isDebuggingOn) println("---\n" + wrapped + "\n---")

--- a/src/main/scala/org/moe/runtime/builtins/IOClass.scala
+++ b/src/main/scala/org/moe/runtime/builtins/IOClass.scala
@@ -143,6 +143,24 @@ object IOClass {
       )
     )
 
+    ioClass.addMethod(
+      new MoeMethod(
+        "input_line_number",
+        new MoeSignature(),
+        env,
+        (e) => self(e).currentLineNumber(r)
+      )
+    )
+
+    ioClass.addMethod(
+      new MoeMethod(
+        "eof",
+        new MoeSignature(),
+        env,
+        (e) => self(e).atEndOfFile(r)
+      )
+    )
+
     /**
      * NOTE:
      * This list needs some work, I have been punting on

--- a/src/main/scala/org/moe/runtime/nativeobjects/MoeIOObject.scala
+++ b/src/main/scala/org/moe/runtime/nativeobjects/MoeIOObject.scala
@@ -59,9 +59,6 @@ class MoeIOObject(
   def readlines (r: MoeRuntime): MoeArrayObject = r.NativeObjects.getArray(
     {
       Source.fromFile(file).getLines.toList.map(r.NativeObjects.getStr(_)):_*
-      // val lines = Source.fromFile(file).getLines
-      // isAtEOF = true
-      // lines.toList.map(r.NativeObjects.getStr(_)):_*
     }
   )
 


### PR DESCRIPTION
Basic support for `-n',`-p`,`-a`and`-F` options.
- provides access to filename(s) in `$ARGV`, and current line number (cumulative) in `$.` (this is kludgy, as a variable with this name could not be created.)
- supports only basic strings for split pattern in `-a` and `-F`. When `split` supports regex patterns, this should work.
- `-p` behavior is not identical to Perl, as there is `continue` block to go with `while` loops.
- I am sure there are other limitations that I haven't thought of.
