### PR TITLE
basic regex support. Just a wrapper for scala (java) regex classes.

### DIFF
--- a/src/main/scala/org/moe/ast/AST.scala
+++ b/src/main/scala/org/moe/ast/AST.scala
@@ -142,3 +142,9 @@ case class DoWhileNode(condition: AST, body: StatementsNode) extends AST
 
 case class ForeachNode(topic: AST, list: AST, body: StatementsNode) extends AST
 case class ForNode(init: AST, condition: AST, update: AST, body: StatementsNode) extends AST
+
+case class RegexLiteralNode(rx: String) extends AST
+case class MatchExpressionNode(pattern: AST, flags: AST) extends AST
+case class SubstExpressionNode(pattern: AST, replacement: AST, flags: AST) extends AST
+case class RegexMatchNode(target: AST, pattern: AST, flags: AST) extends AST
+case class RegexSubstNode(target: AST, pattern: AST, replacement: AST, flags: AST) extends AST

--- a/src/main/scala/org/moe/ast/Serializer.scala
+++ b/src/main/scala/org/moe/ast/Serializer.scala
@@ -18,6 +18,8 @@ object Serializer {
     case ClassLiteralNode() => "ClassLiteralNode"
     case SuperCallNode() => "SuperCallNode"
 
+    case RegexLiteralNode(value) => JSONObject(Map("RegexLiteralNode" -> value.toString))
+
     case PairLiteralNode(key, value) => JSONObject(
       Map(
         "PairLiteralNode" -> JSONObject(
@@ -476,6 +478,54 @@ object Serializer {
             "condition" -> toJSON(condition),
             "update"    -> toJSON(update),
             "body"      -> toJSON(body)
+          )
+        )
+      )
+    )
+
+    case RegexMatchNode(target, pattern, flags) => JSONObject(
+      Map(
+        "RegexMatchNode" -> JSONObject(
+          Map(
+            "target"  -> toJSON(target),
+            "pattern" -> toJSON(pattern),
+            "flags"   -> toJSON(flags)
+          )
+        )
+      )
+    )
+
+    case RegexSubstNode(target, pattern, replacement, flags) => JSONObject(
+      Map(
+        "RegexSubstNode" -> JSONObject(
+          Map(
+            "target"      -> toJSON(target),
+            "pattern"     -> toJSON(pattern),
+            "replacement" -> toJSON(replacement),
+            "flags"       -> toJSON(flags)
+          )
+        )
+      )
+    )
+
+    case MatchExpressionNode(pattern, flags) => JSONObject(
+      Map(
+        "MatchExpressionNode" -> JSONObject(
+          Map(
+            "pattern" -> toJSON(pattern),
+            "flags"   -> toJSON(flags)
+          )
+        )
+      )
+    )
+
+    case SubstExpressionNode(pattern, replacement, flags) => JSONObject(
+      Map(
+        "SubstExpressionNode" -> JSONObject(
+          Map(
+            "pattern"     -> toJSON(pattern),
+            "replacement" -> toJSON(replacement),
+            "flags"       -> toJSON(flags)
           )
         )
       )

--- a/src/main/scala/org/moe/interpreter/guts/Literals.scala
+++ b/src/main/scala/org/moe/interpreter/guts/Literals.scala
@@ -81,6 +81,18 @@ object Literals extends Utils {
       r.NativeObjects.getArray(result:_*)
     }
 
+    case (env, RegexLiteralNode(value)) => r.NativeObjects.getRegex(value)
+
+    case (env, MatchExpressionNode(pattern: AST, flags: AST)) =>
+      (pattern, flags) match {
+        case (RegexLiteralNode(p), StringLiteralNode(f)) => r.NativeObjects.getRegex(p, f)
+      }
+
+    case (env, SubstExpressionNode(pattern: AST, replacement: AST, flags: AST)) =>
+      (pattern, replacement, flags) match {
+        case (RegexLiteralNode(p), StringLiteralNode(r_), StringLiteralNode(f)) =>
+         r.NativeObjects.getArray(List(r.NativeObjects.getRegex(p, f), r.NativeObjects.getStr(r_)) : _*)
+      }
   }
 
 }

--- a/src/main/scala/org/moe/interpreter/guts/Operators.scala
+++ b/src/main/scala/org/moe/interpreter/guts/Operators.scala
@@ -31,6 +31,15 @@ object Operators extends Utils {
       }
     }
 
+    // regexes
+
+    case (env, BinaryOpNode(lhs: AST, "=~", rhs: AST)) => {
+      rhs match {
+        case MatchExpressionNode(pattern, flags) => i.evaluate(env, RegexMatchNode(lhs, pattern, flags))
+        case SubstExpressionNode(pattern, replacement, flags) => i.evaluate(env, RegexSubstNode(lhs, pattern, replacement, flags))
+      }
+    }
+
     // other binary operators
 
     case (env, BinaryOpNode(lhs: AST, operator: String, rhs: AST)) => {
@@ -56,5 +65,23 @@ object Operators extends Utils {
       val argFalse = new MoeLazyEval(i, env, falseExpr)
       callMethod(receiver, "infix:<?:>", List(argTrue, argFalse))
     }
+
+    // regex operations
+
+    case (env, RegexMatchNode(target: AST, pattern: AST, flags: AST)) => {
+      val receiver = i.evaluate(env, target)
+      val argPattern = i.evaluate(env, pattern)
+      val argFlags = i.evaluate(env, flags);
+      callMethod(receiver, "match", List(argPattern, argFlags))
+    }
+
+    case (env, RegexSubstNode(target: AST, pattern: AST, replacement: AST, flags: AST)) => {
+      val receiver = i.evaluate(env, target)
+      val argPattern = i.evaluate(env, pattern)
+      val argReplacement = i.evaluate(env, replacement)
+      val argFlags = i.evaluate(env, flags);
+      callMethod(receiver, "subst", List(argPattern, argReplacement, argFlags))
+    }
+
   }
 }

--- a/src/main/scala/org/moe/parser/MoeLiterals.scala
+++ b/src/main/scala/org/moe/parser/MoeLiterals.scala
@@ -66,6 +66,13 @@ trait MoeLiterals extends JavaTokenParsers {
   def selfLiteral  : Parser[SelfLiteralNode]  = "self".r ^^^ SelfLiteralNode()
   def superLiteral : Parser[SuperCallNode] = "super".r ^^^ SuperCallNode()
 
+  // Regex Literal
+
+  def regexString = """(\\.|[^/])*""".r
+
+  // TODO: support for other delimiters
+  def regexLiteral: Parser[RegexLiteralNode] = "/" ~> regexString <~ "/" ^^ { rx => RegexLiteralNode(rx) }
+
   def literalValue: Parser[AST] = (
       floatNumber
     | intNumber
@@ -79,5 +86,6 @@ trait MoeLiterals extends JavaTokenParsers {
     | string
     | selfLiteral
     | superLiteral
+    | regexLiteral
   )
 }

--- a/src/main/scala/org/moe/runtime/MoeRuntime.scala
+++ b/src/main/scala/org/moe/runtime/MoeRuntime.scala
@@ -102,6 +102,7 @@ class MoeRuntime (
       val intClass       = new MoeClass("Int",        Some(VERSION), Some(AUTHORITY), Some(scalarClass))
       val numClass       = new MoeClass("Num",        Some(VERSION), Some(AUTHORITY), Some(scalarClass))
       val exceptionClass = new MoeClass("Exception",  Some(VERSION), Some(AUTHORITY), Some(scalarClass))
+      val regexClass     = new MoeClass("Regex",      Some(VERSION), Some(AUTHORITY), Some(scalarClass))
 
       // set the associated class for all classes
       // this must be classClass because these are
@@ -120,6 +121,7 @@ class MoeRuntime (
       intClass.setAssociatedType(Some(MoeClassType(Some(coreClassClass))))
       numClass.setAssociatedType(Some(MoeClassType(Some(coreClassClass))))
       exceptionClass.setAssociatedType(Some(MoeClassType(Some(coreClassClass))))
+      regexClass.setAssociatedType(Some(MoeClassType(Some(coreClassClass))))
 
       // add all these classes to the corePackage
       corePackage.addClass(objectClass)
@@ -140,6 +142,7 @@ class MoeRuntime (
       corePackage.addClass(intClass)
       corePackage.addClass(numClass)
       corePackage.addClass(exceptionClass)
+      corePackage.addClass(regexClass)
 
       setupBuiltins
 
@@ -280,6 +283,9 @@ class MoeRuntime (
       e.setValue("$!msg", getStr(msg))
       e
     }
+
+    def getRegex (rx: String) = new MoeRegexObject(rx, None, Some(MoeScalarType(getCoreClassFor("Regex"))))
+    def getRegex (rx: String, flags: String) = new MoeRegexObject(rx, Some(flags), Some(MoeScalarType(getCoreClassFor("Regex"))))
 
     def fixupSubroutine (c: MoeSubroutine): MoeSubroutine = {
       c.setAssociatedType(Some(MoeCodeType(getCoreClassFor("Code"))))

--- a/src/main/scala/org/moe/runtime/builtins/StrClass.scala
+++ b/src/main/scala/org/moe/runtime/builtins/StrClass.scala
@@ -265,6 +265,45 @@ object StrClass {
       )
     )
 
+    // regex matching
+    strClass.addMethod(
+      new MoeMethod(
+        "match",
+        new MoeSignature(List(new MoePositionalParameter("$rx"),
+                              new MoeOptionalParameter("$flags"))),
+        env,
+        (e) => {
+          e.get("$rx") match {
+            case Some(rx: MoeRegexObject) => self(e).matches(r, rx)
+            case Some(s:  MoeStrObject)   => self(e).matches(r, s)
+            case _                        => throw new MoeErrors.IncompatibleType("Str or Regex expected")
+          }
+        }
+      )
+    )
+
+    strClass.addMethod(
+      new MoeMethod(
+        "subst",
+        new MoeSignature(List(new MoePositionalParameter("$rx"),
+                              new MoePositionalParameter("$replacement"),
+                              new MoeOptionalParameter("$flags"))),
+        env,
+        (e) => {
+          val replacement = e.getAs[MoeStrObject]("$replacement").get
+          val flags     = e.get("$flags") match {
+            case Some(s: MoeStrObject) => s.copy
+            case _                     => getStr("")
+          }
+          e.get("$rx") match {
+            case Some(rx: MoeRegexObject) => self(e).subst(r, rx, replacement, flags)
+            case Some(s:  MoeStrObject)   => self(e).subst(r, s, replacement, flags)
+            case _                        => throw new MoeErrors.IncompatibleType("Str or Regex expected")
+          }
+        }
+      )
+    )
+
     /**
      * List of Operators to support:
      * - infix:<.>

--- a/src/main/scala/org/moe/runtime/nativeobjects/MoeRegexObject.scala
+++ b/src/main/scala/org/moe/runtime/nativeobjects/MoeRegexObject.scala
@@ -1,0 +1,75 @@
+package org.moe.runtime.nativeobjects
+
+import org.moe.runtime._
+import org.moe.runtime.nativeobjects._
+
+import scala.util.matching.Regex
+
+class MoeRegexObject(
+  rx: String,
+  flags: Option[String] = None, 
+  t: Option[MoeType] = None
+  ) extends MoeNativeObject[(String, Option[String])]((rx, flags), t) {
+
+  private val regex = new Regex(rx).unanchored
+
+  def getRegex = regex
+  def getFlags = flags.getOrElse("")
+
+  def matches (r: MoeRuntime, text: MoeStrObject): MoeBoolObject = r.NativeObjects.getBool(
+    regex.findFirstIn(text.unboxToString.get).nonEmpty
+  )
+
+  private def regexFlagsToMap(flags: String): Map[String, Boolean] = {
+    val validFlags = Map(
+      'i' -> "ignore_case",
+      'g' -> "global",
+      'm' -> "match_multiple_lines",
+      's' -> "match_single_line",
+      'x' -> "extended"
+    )
+    (for (f <- flags) yield (validFlags(f) -> true)).toMap
+  }
+
+  def find (r: MoeRuntime,
+    target: MoeStrObject,
+    flags: Option[MoeStrObject] = None
+  ) = {
+    val f: String = flags match {
+      case Some(f) => f.unboxToString.get
+      case None    => getFlags
+    }
+
+    // TODO: other flags
+    val find_all = regexFlagsToMap(f).getOrElse("global", false)
+    val matches = if (find_all)
+      regex.findAllIn(target.unboxToString.get)
+    else
+      regex.findFirstIn(target.unboxToString.get)
+  }
+
+  def replace (
+    r: MoeRuntime,
+    target: MoeStrObject,
+    replacement: MoeStrObject,
+    flags: Option[MoeStrObject]
+    ): MoeStrObject = {
+    val f = flags match {
+      case Some(f) => f.unboxToString.get
+      case None    => getFlags
+    }
+    val replace_all = regexFlagsToMap(f).getOrElse("global", false)
+    // TODO: other flags
+    r.NativeObjects.getStr(
+      if (replace_all)
+        regex.replaceAllIn(target.unboxToString.get, replacement.unboxToString.get)
+      else
+        regex.replaceFirstIn(target.unboxToString.get, replacement.unboxToString.get)
+    )
+  }
+
+  // MoeNativeObject overrides
+
+  override def copy = new MoeRegexObject(getNativeValue._1, getNativeValue._2, getAssociatedType)
+
+}

--- a/src/main/scala/org/moe/runtime/nativeobjects/MoeStrObject.scala
+++ b/src/main/scala/org/moe/runtime/nativeobjects/MoeStrObject.scala
@@ -103,6 +103,37 @@ class MoeStrObject(
   def greater_than_or_equal_to (r: MoeRuntime, other: MoeObject): MoeBoolObject =
     r.NativeObjects.getBool(getNativeValue >= other.unboxToString.get)
 
+  // regular expression matching
+
+  def matches (r: MoeRuntime, pattern: MoeStrObject): MoeBoolObject =
+    new MoeRegexObject(pattern.unboxToString.get).matches(r, this)
+
+  def matches (r: MoeRuntime, pattern: MoeRegexObject): MoeBoolObject =
+    pattern.matches(r, this)
+
+  // TODO: find method that returns a "Match" object to access captures etc
+
+  def subst (
+    r: MoeRuntime,
+    pattern: MoeStrObject,
+    replacement: MoeStrObject,
+    flags: MoeStrObject
+  ): MoeStrObject =
+    r.NativeObjects.getStr(
+      if (flags.unboxToString.get == "g")
+        getNativeValue.replace(pattern.unboxToString.get, replacement.unboxToString.get)
+      else
+        getNativeValue.replaceFirst(pattern.unboxToString.get, replacement.unboxToString.get)
+    )
+
+  def subst (
+    r: MoeRuntime,
+    pattern: MoeRegexObject,
+    replacement: MoeStrObject,
+    flags: MoeStrObject
+  ): MoeStrObject =
+    pattern.replace(r, this, replacement, Some(flags))
+
   // MoeNativeObject overrides
 
   override def copy = new MoeStrObject(getNativeValue, getAssociatedType)

--- a/src/test/scala/org/moe/interpreter/RegexTestSuite.scala
+++ b/src/test/scala/org/moe/interpreter/RegexTestSuite.scala
@@ -1,0 +1,69 @@
+package org.moe.interpreter
+
+import org.scalatest.FunSuite
+import org.scalatest.BeforeAndAfter
+import org.scalatest.matchers.ShouldMatchers
+
+import org.moe.runtime._
+import org.moe.interpreter._
+import org.moe.ast._
+import org.moe.parser._
+import org.moe.runtime.nativeobjects._
+
+class RegexTestSuite extends FunSuite with BeforeAndAfter with ParserTestUtils with ShouldMatchers {
+
+  test("... basic test with regex match -- string pattern") {
+    val result = interpretCode(""""foo".match("foo")""")
+    result.unboxToBoolean.get should equal (true)
+  }
+
+  test("... basic test with regex match -- delimited pattern") {
+    val result = interpretCode(""""foo".match(/foo/)""")
+    result.unboxToBoolean.get should equal (true)
+  }
+
+  test("... basic test with regex match -- anchored at beginning") {
+    val result = interpretCode(""""foo".match(/^f/)""")
+    result.unboxToBoolean.get should equal (true)
+  }
+
+  test("... basic test with regex match -- anchored at end") {
+    val result = interpretCode(""""foo".match(/o$/)""")
+    result.unboxToBoolean.get should equal (true)
+  }
+
+  test("... basic test with regex match -- string pattern -- no match") {
+    val result = interpretCode(""""foo".match("f00")""")
+    result.unboxToBoolean.get should equal (false)
+  }
+
+  test("... basic test with regex match -- variable with delimited pattern") {
+    val result = interpretCode("""my $foo = "foo"; $foo.match(/foo/)""")
+    result.unboxToBoolean.get should equal (true)
+  }
+
+  test("... basic test with regex match -- delimited pattern -- no match") {
+    val result = interpretCode(""""foo".match("f00")""")
+    result.unboxToBoolean.get should equal (false)
+  }
+
+  test("... basic test with regex substitution -- string pattern") {
+    val result = interpretCode(""""foo".subst("f", "F")""")
+    result.unboxToString.get should equal ("Foo")
+  }
+
+  test("... basic test with regex substitution -- delimited pattern") {
+    val result = interpretCode(""""foo".subst(/o+$/, "00")""")
+    result.unboxToString.get should equal ("f00")
+  }
+
+  test("... basic test with regex substitution -- string pattern -- no match") {
+    val result = interpretCode(""""foo".subst("a", "A")""")
+    result.unboxToString.get should equal ("foo")
+  }
+
+  test("... basic test with regex substitution -- delimited pattern -- no match") {
+    val result = interpretCode(""""foo".subst(/O+$/, "00")""")
+    result.unboxToString.get should equal ("foo")
+  }
+}

--- a/t/007-regexes/001-match.t
+++ b/t/007-regexes/001-match.t
@@ -1,0 +1,26 @@
+use Test::More;
+
+ok("foo".match("foo"),  '... basic string match using .match method');
+ok("foo".match(/^foo$/), '... basic regex match using .match method');
+
+{
+    my $str = "abrAcadAbbra";
+    ok($str.match(/a.+A/), '... regex match on str variable using .match method');
+}
+
+{
+    my $str = 'hello';
+    ok($str.match(/h/), '... pattern match using regex using .match method');
+    is($str, 'hello',   '..... with no side effect');
+}
+
+ok("foo" =~ /f/, "... string literal match with =~ operator");
+ok("foo" =~ m/f/, "... string literal match with =~ and explicit 'm' operator");
+
+{
+    my $str = "foo";
+    ok($str =~ /f/, "... string variable match with =~ operator");
+    ok($str =~ m/f/, "... string variable match with =~ and explicit 'm' operator");
+}
+
+done_testing();

--- a/t/007-regexes/002-subst.t
+++ b/t/007-regexes/002-subst.t
@@ -1,0 +1,31 @@
+use Test::More;
+
+is("foo".subst(/^f/, "F"), "Foo", '... basic regex substitution');
+is("foo".subst(/o/, "0"), "f0o", '... basic regex substitution');
+is("foo".subst(/o/, "0", "g"), "f00", '... basic regex substitution with global flag');
+
+{
+    my $str = "abrAcadAbbra";
+    is($str.subst(/a.+A/, ""), "bbra", '... regex substitution on str variable');
+    is($str.subst(/a.+?A/, ""), "cadAbbra", '... regex substitution on str variable');
+    is($str, "abrAcadAbbra", '... with no side effect');
+}
+
+is("foo" =~ s/f/g/, "goo", "... string literal substitution with =~ operator");
+is("foo" =~ s/o/0/g, "f00", "... string literal global substitution with =~ operator");
+
+{
+    my $str = "foo";
+    is($str =~ s/f/g/, "goo", "... str variable substitution with =~ operator");
+    is($str =~ s/o/0/g, "f00", "... str variable global substitution with =~ operator");
+    is($str, "foo", "... with no side effect")
+}
+
+{
+    my $str = "foo";
+    is($str =~ s/(.)/$1$1/, "ffoo", "... str variable substitution with capture");
+    is($str =~ s/(.)/$1$1/g, "ffoooo", "... str variable global substitution with capture");
+    is($str =~ s/(.)(.)/$2$1/, "ofo", "... str variable substitution with capture");
+}
+
+done_testing();


### PR DESCRIPTION
This is just barely scratching the surface of what Perl's regex capabilities. Only supports // as delimiters.

In order to realize anything close to what Perl offers, we will probably need to write our own parser class, that should also help us implement string interpolation and quote operators (q, qq etc).
