### PR TITLE
__PACKAGE__() as a sub, not a special token

### DIFF
--- a/src/main/scala/org/moe/runtime/builtins/CorePackage.scala
+++ b/src/main/scala/org/moe/runtime/builtins/CorePackage.scala
@@ -229,5 +229,22 @@ object CorePackage {
         }
       )
     )
+
+    pkg.addSubroutine(
+      new MoeSubroutine(
+        "__PACKAGE__",
+        new MoeSignature(),
+        env,
+        { (e) =>
+          val caller_env = r.getInterpreterCallStack.head.getCallSiteEnvironment
+          val caller_pkg = caller_env.getCurrentPackage match {
+            case Some(x) => x.getFullyQualifiedName
+            case None    => ""
+            case _       => ""
+          }
+          getStr(caller_pkg)
+        }
+      )
+    )
   }
 }

--- a/t/100-builtins/008-package.t
+++ b/t/100-builtins/008-package.t
@@ -1,0 +1,9 @@
+use Test::More;
+
+package Bar {
+    sub quux { __PACKAGE__() }
+}
+
+is(Bar::quux(), "Bar", '__PACKAGE__ returns what we expect');
+
+done_testing();


### PR DESCRIPTION
I added **PACKAGE** as a sub, and I would like to check whether this is the right basic idea. It seems like to make it work as just **PACKAGE**, I need to make it something like selfLiteral in MoeLiterals or I need to provide some special keyword parser, like for subroutineCall in MoeProductions.
